### PR TITLE
Add missing shoulder aruco

### DIFF
--- a/hello_robot_stretch/stretch.xml
+++ b/hello_robot_stretch/stretch.xml
@@ -245,11 +245,6 @@
         <geom mesh="link_lift_7" class="collision"/>
         <geom mesh="link_lift_8" class="collision" mass="1.5"/>
         <geom mesh="link_lift_9" class="collision" mass="1.5"/>
-        <body name="link_aruco_shoulder" pos="-0.015 0.054 0.087" quat="1 0 0 1">
-          <geom material="Aruco_Shoulder_Sticker" mesh="link_aruco_shoulder" class="visual" mass="3.6E-06"
-            shellinertia="true"/>
-          <geom mesh="link_aruco_shoulder" class="collision"/>
-        </body>
         <body name="link_arm_l4" gravcomp="1">
           <geom mesh="link_arm_l4_0" pos="-0.2547 0 0" quat="0.5 0.5 -0.5 -0.5" material="Carbon_Fiber" class="visual"/>
           <geom mesh="link_arm_l4_1" pos="-0.2547 0 0" quat="0.5 0.5 -0.5 -0.5" material="3D_Print_Black" class="visual"/>
@@ -340,6 +335,11 @@
               </body>
             </body>
           </body>
+        </body>
+        <body name="link_aruco_shoulder" pos="-0.0133769 0.0558541 0.0865" quat="1 0 0 0">
+          <geom material="Aruco_Shoulder_Sticker" mesh="link_aruco_shoulder" class="visual" mass="3.6E-06"
+          shellinertia="true"/>
+          <geom mesh="link_aruco_shoulder" class="collision"/>
         </body>
       </body>
       <body name="link_head_pan" pos="0.00610002 0 1.3552" quat="-1 0 0 0">

--- a/hello_robot_stretch/stretch.xml
+++ b/hello_robot_stretch/stretch.xml
@@ -67,6 +67,7 @@
     <texture type="2d" file="hand_pinch.png"/>
     <texture type="2d" file="arm_inner_wrist_aruco_sticker.png"/>
     <texture type="2d" file="arm_top_wrist_aruco_sticker.png"/>
+    <texture type="2d" file="shoulder_aruco_sticker.png"/>
 
     <material name="Caster_Rollers_Red" rgba="0.8 0.001381 0 1"/>
     <material name="Generic_Black" rgba="0.036889 0.036889 0.036889 1"/>
@@ -95,6 +96,7 @@
     <material name="Aruco_Inner_Wrist_Sticker" texture="arm_inner_wrist_aruco_sticker"/>
     <material name="Aruco_Top_Wrist_Sticker" texture="arm_top_wrist_aruco_sticker"/>
     <material name="suction_rubber" rgba="0.25098 0.25098 0.25098 1"/>
+    <material name="Aruco_Shoulder_Sticker" texture="shoulder_aruco_sticker"/>
 
     <mesh file="base_link_0.obj"/>
     <mesh file="base_link_2.obj"/>
@@ -139,6 +141,7 @@
     <mesh file="link_lift_7.obj"/>
     <mesh file="link_lift_8.obj"/>
     <mesh file="link_lift_9.obj"/>
+    <mesh file="link_aruco_shoulder.obj"/>
     <mesh file="link_arm_l4_0.obj"/>
     <mesh file="link_arm_l4_1.obj"/>
     <mesh file="link_arm_l3_0.obj"/>
@@ -242,6 +245,11 @@
         <geom mesh="link_lift_7" class="collision"/>
         <geom mesh="link_lift_8" class="collision" mass="1.5"/>
         <geom mesh="link_lift_9" class="collision" mass="1.5"/>
+        <body name="link_aruco_shoulder" pos="-0.015 0.054 0.087" quat="1 0 0 1">
+          <geom material="Aruco_Shoulder_Sticker" mesh="link_aruco_shoulder" class="visual" mass="3.6E-06"
+            shellinertia="true"/>
+          <geom mesh="link_aruco_shoulder" class="collision"/>
+        </body>
         <body name="link_arm_l4" gravcomp="1">
           <geom mesh="link_arm_l4_0" pos="-0.2547 0 0" quat="0.5 0.5 -0.5 -0.5" material="Carbon_Fiber" class="visual"/>
           <geom mesh="link_arm_l4_1" pos="-0.2547 0 0" quat="0.5 0.5 -0.5 -0.5" material="3D_Print_Black" class="visual"/>


### PR DESCRIPTION
This PR adds the missing shoulder aruco tag on Hello Robot's Stretch robot. The pose of link_aruco_shoulder is eyeballed for now, so I recommend checking the CAD to insert the pin point accurate values.

Before:
![Screenshot from 2023-10-05 19-31-12](https://github.com/google-deepmind/mujoco_menagerie/assets/97639181/611d5523-6499-445e-9b67-2d5b61f56312)

After:
![Screenshot from 2023-10-05 19-30-08](https://github.com/google-deepmind/mujoco_menagerie/assets/97639181/b2b63c0f-017f-44d9-bfe6-151739a8bc68)
