### PR TITLE
Remove separators from panda_nohand.xml default classes

### DIFF
--- a/franka_emika_panda/panda_nohand.xml
+++ b/franka_emika_panda/panda_nohand.xml
@@ -8,17 +8,16 @@
       <material specular="0.5" shininess="0.25"/>
       <joint armature="0.1" damping="1" axis="0 0 1" range="-2.8973 2.8973"/>
       <general dyntype="none" biastype="affine" ctrlrange="-2.8973 2.8973" forcerange="-87 87"/>
-      <default class="finger">
-        <joint axis="0 1 0" type="slide" range="0 0.04"/>
-      </default>
+      <site size="0.001" rgba="0.5 0.5 0.5 0.3" group="4"/>
 
-      <default class="panda/visual">
+      <default class="visual">
         <geom type="mesh" contype="0" conaffinity="0" group="2"/>
       </default>
-      <default class="panda/collision">
+
+      <default class="collision">
         <geom type="mesh" group="3"/>
       </default>
-      <site size="0.001" rgba="0.5 0.5 0.5 0.3" group="4"/>
+
     </default>
   </default>
 
@@ -98,93 +97,93 @@
     <body name="link0" childclass="panda">
       <inertial mass="0.629769" pos="-0.041018 -0.00014 0.049974"
         fullinertia="0.00315 0.00388 0.004285 8.2904e-7 0.00015 8.2299e-6"/>
-      <geom mesh="link0_0" material="off_white" class="panda/visual"/>
-      <geom mesh="link0_1" material="dark_grey" class="panda/visual"/>
-      <geom mesh="link0_2" material="off_white" class="panda/visual"/>
-      <geom mesh="link0_3" material="dark_grey" class="panda/visual"/>
-      <geom mesh="link0_4" material="off_white" class="panda/visual"/>
-      <geom mesh="link0_5" material="dark_grey" class="panda/visual"/>
-      <geom mesh="link0_7" material="white" class="panda/visual"/>
-      <geom mesh="link0_8" material="white" class="panda/visual"/>
-      <geom mesh="link0_9" material="dark_grey" class="panda/visual"/>
-      <geom mesh="link0_10" material="off_white" class="panda/visual"/>
-      <geom mesh="link0_11" material="white" class="panda/visual"/>
-      <geom mesh="link0_c" class="panda/collision"/>
+      <geom mesh="link0_0" material="off_white" class="visual"/>
+      <geom mesh="link0_1" material="dark_grey" class="visual"/>
+      <geom mesh="link0_2" material="off_white" class="visual"/>
+      <geom mesh="link0_3" material="dark_grey" class="visual"/>
+      <geom mesh="link0_4" material="off_white" class="visual"/>
+      <geom mesh="link0_5" material="dark_grey" class="visual"/>
+      <geom mesh="link0_7" material="white" class="visual"/>
+      <geom mesh="link0_8" material="white" class="visual"/>
+      <geom mesh="link0_9" material="dark_grey" class="visual"/>
+      <geom mesh="link0_10" material="off_white" class="visual"/>
+      <geom mesh="link0_11" material="white" class="visual"/>
+      <geom mesh="link0_c" class="collision"/>
       <body name="link1" pos="0 0 0.333">
         <inertial mass="4.970684" pos="0.003875 0.002081 -0.04762"
           fullinertia="0.70337 0.70661 0.0091170 -0.00013900 0.0067720 0.019169"/>
         <joint name="joint1"/>
-        <geom material="white" mesh="link1" class="panda/visual"/>
-        <geom mesh="link1_c" class="panda/collision"/>
+        <geom material="white" mesh="link1" class="visual"/>
+        <geom mesh="link1_c" class="collision"/>
         <body name="link2" quat="1 -1 0 0">
           <inertial mass="0.646926" pos="-0.003141 -0.02872 0.003495"
             fullinertia="0.0079620 2.8110e-2 2.5995e-2 -3.925e-3 1.0254e-2 7.04e-4"/>
           <joint name="joint2" range="-1.7628 1.7628"/>
-          <geom material="white" mesh="link2" class="panda/visual"/>
-          <geom mesh="link2_c" class="panda/collision"/>
+          <geom material="white" mesh="link2" class="visual"/>
+          <geom mesh="link2_c" class="collision"/>
           <body name="link3" pos="0 -0.316 0" quat="1 1 0 0">
             <joint name="joint3"/>
             <inertial mass="3.228604" pos="2.7518e-2 3.9252e-2 -6.6502e-2"
               fullinertia="3.7242e-2 3.6155e-2 1.083e-2 -4.761e-3 -1.1396e-2 -1.2805e-2"/>
-            <geom mesh="link3_0" material="white" class="panda/visual"/>
-            <geom mesh="link3_1" material="white" class="panda/visual"/>
-            <geom mesh="link3_2" material="white" class="panda/visual"/>
-            <geom mesh="link3_3" material="dark_grey" class="panda/visual"/>
-            <geom mesh="link3_c" class="panda/collision"/>
+            <geom mesh="link3_0" material="white" class="visual"/>
+            <geom mesh="link3_1" material="white" class="visual"/>
+            <geom mesh="link3_2" material="white" class="visual"/>
+            <geom mesh="link3_3" material="dark_grey" class="visual"/>
+            <geom mesh="link3_c" class="collision"/>
             <body name="link4" pos="0.0825 0 0" quat="1 1 0 0">
               <inertial mass="3.587895" pos="-5.317e-2 1.04419e-1 2.7454e-2"
                 fullinertia="2.5853e-2 1.9552e-2 2.8323e-2 7.796e-3 -1.332e-3 8.641e-3"/>
               <joint name="joint4" range="-3.0718 -0.0698"/>
-              <geom mesh="link4_0" material="white" class="panda/visual"/>
-              <geom mesh="link4_1" material="white" class="panda/visual"/>
-              <geom mesh="link4_2" material="dark_grey" class="panda/visual"/>
-              <geom mesh="link4_3" material="white" class="panda/visual"/>
-              <geom mesh="link4_c" class="panda/collision"/>
+              <geom mesh="link4_0" material="white" class="visual"/>
+              <geom mesh="link4_1" material="white" class="visual"/>
+              <geom mesh="link4_2" material="dark_grey" class="visual"/>
+              <geom mesh="link4_3" material="white" class="visual"/>
+              <geom mesh="link4_c" class="collision"/>
               <body name="link5" pos="-0.0825 0.384 0" quat="1 -1 0 0">
                 <inertial mass="1.225946" pos="-1.1953e-2 4.1065e-2 -3.8437e-2"
                   fullinertia="3.5549e-2 2.9474e-2 8.627e-3 -2.117e-3 -4.037e-3 2.29e-4"/>
                 <joint name="joint5"/>
-                <geom mesh="link5_0" material="dark_grey" class="panda/visual"/>
-                <geom mesh="link5_1" material="white" class="panda/visual"/>
-                <geom mesh="link5_2" material="white" class="panda/visual"/>
-                <geom mesh="link5_c0" class="panda/collision"/>
-                <geom mesh="link5_c1" class="panda/collision"/>
-                <geom mesh="link5_c2" class="panda/collision"/>
+                <geom mesh="link5_0" material="dark_grey" class="visual"/>
+                <geom mesh="link5_1" material="white" class="visual"/>
+                <geom mesh="link5_2" material="white" class="visual"/>
+                <geom mesh="link5_c0" class="collision"/>
+                <geom mesh="link5_c1" class="collision"/>
+                <geom mesh="link5_c2" class="collision"/>
                 <body name="link6" quat="1 1 0 0">
                   <inertial mass="1.666555" pos="6.0149e-2 -1.4117e-2 -1.0517e-2"
                     fullinertia="1.964e-3 4.354e-3 5.433e-3 1.09e-4 -1.158e-3 3.41e-4"/>
                   <joint name="joint6" range="-0.0175 3.7525"/>
-                  <geom mesh="link6_0" material="off_white" class="panda/visual"/>
-                  <geom mesh="link6_1" material="white" class="panda/visual"/>
-                  <geom mesh="link6_2" material="dark_grey" class="panda/visual"/>
-                  <geom mesh="link6_3" material="white" class="panda/visual"/>
-                  <geom mesh="link6_4" material="white" class="panda/visual"/>
-                  <geom mesh="link6_5" material="white" class="panda/visual"/>
-                  <geom mesh="link6_6" material="white" class="panda/visual"/>
-                  <geom mesh="link6_7" material="light_blue" class="panda/visual"/>
-                  <geom mesh="link6_8" material="light_blue" class="panda/visual"/>
-                  <geom mesh="link6_9" material="dark_grey" class="panda/visual"/>
-                  <geom mesh="link6_10" material="dark_grey" class="panda/visual"/>
-                  <geom mesh="link6_11" material="white" class="panda/visual"/>
-                  <geom mesh="link6_12" material="green" class="panda/visual"/>
-                  <geom mesh="link6_13" material="white" class="panda/visual"/>
-                  <geom mesh="link6_14" material="dark_grey" class="panda/visual"/>
-                  <geom mesh="link6_15" material="dark_grey" class="panda/visual"/>
-                  <geom mesh="link6_16" material="white" class="panda/visual"/>
-                  <geom mesh="link6_c" class="panda/collision"/>
+                  <geom mesh="link6_0" material="off_white" class="visual"/>
+                  <geom mesh="link6_1" material="white" class="visual"/>
+                  <geom mesh="link6_2" material="dark_grey" class="visual"/>
+                  <geom mesh="link6_3" material="white" class="visual"/>
+                  <geom mesh="link6_4" material="white" class="visual"/>
+                  <geom mesh="link6_5" material="white" class="visual"/>
+                  <geom mesh="link6_6" material="white" class="visual"/>
+                  <geom mesh="link6_7" material="light_blue" class="visual"/>
+                  <geom mesh="link6_8" material="light_blue" class="visual"/>
+                  <geom mesh="link6_9" material="dark_grey" class="visual"/>
+                  <geom mesh="link6_10" material="dark_grey" class="visual"/>
+                  <geom mesh="link6_11" material="white" class="visual"/>
+                  <geom mesh="link6_12" material="green" class="visual"/>
+                  <geom mesh="link6_13" material="white" class="visual"/>
+                  <geom mesh="link6_14" material="dark_grey" class="visual"/>
+                  <geom mesh="link6_15" material="dark_grey" class="visual"/>
+                  <geom mesh="link6_16" material="white" class="visual"/>
+                  <geom mesh="link6_c" class="collision"/>
                   <body name="link7" pos="0.088 0 0" quat="1 1 0 0">
                     <inertial mass="7.35522e-01" pos="1.0517e-2 -4.252e-3 6.1597e-2"
                       fullinertia="1.2516e-2 1.0027e-2 4.815e-3 -4.28e-4 -1.196e-3 -7.41e-4"/>
                     <joint name="joint7"/>
-                    <geom mesh="link7_0" material="white" class="panda/visual"/>
-                    <geom mesh="link7_1" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_2" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_3" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_4" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_5" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_6" material="dark_grey" class="panda/visual"/>
-                    <geom mesh="link7_7" material="white" class="panda/visual"/>
-                    <geom mesh="link7_c" class="panda/collision"/>
+                    <geom mesh="link7_0" material="white" class="visual"/>
+                    <geom mesh="link7_1" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_2" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_3" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_4" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_5" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_6" material="dark_grey" class="visual"/>
+                    <geom mesh="link7_7" material="white" class="visual"/>
+                    <geom mesh="link7_c" class="collision"/>
                     <body name="attachment" pos="0 0 0.107" quat="0.3826834 0 0 0.9238795">
                       <site name="attachment_site"/>
                     </body>


### PR DESCRIPTION
I encountered an error when migrating to the [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py) package related to reading official mjcf files that contain separators in class names. Further details of this issue can be found [here](https://github.com/google-deepmind/dm_control/issues/473).

This pull request updates the [panda_nohand.xml](https://github.com/google-deepmind/mujoco_menagerie/blob/main/franka_emika_panda/panda_nohand.xml) model by renaming default class names to ensure the model can be read using the `dm_control.mjcf` API. 