### PR TITLE
make unitree go2 mjx model compatible with hfields

### DIFF
--- a/unitree_go2/go2_mjx.xml
+++ b/unitree_go2/go2_mjx.xml
@@ -1,13 +1,13 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option cone="pyramidal" impratio="100" iterations="1" ls_iterations="5">
+  <option cone="pyramidal" iterations="1" ls_iterations="5">
     <flag eulerdamp="disable"/>
   </option>
 
   <default>
     <default class="go2">
-      <geom friction="0.6" margin="0.001" condim="1"/>
+      <geom friction="0.6" condim="1"/>
       <joint axis="0 1 0" damping="2" armature="0.01"/>
       <general forcerange="-24 24" biastype="affine" gainprm="50 0 0" biasprm="0 -50 -0.5"/>
 


### PR DESCRIPTION
I had two issues when attempting to use `unitree_go2/go2_mjx.xml` in scenes with hfields such as `google_barkour_vb/scene_hfield_mjx.xml`:

1) the `margin` attribute in the `go2` class default section results in the following error:

> NotImplementedError: (mjtGeom.mjGEOM_HFIELD, mjtGeom.mjGEOM_SPHERE) margin/gap not implemented.

2) the impratio="100" option setting makes the scene unstable with mjx acceleration (specifically, I encountered nan qpos values)

This PR removes these two attributes, resulting in no `margin` and an `impratio="1"` default.

I don't have a full understanding of how these changes affect the simulation. Please determine if they should be merged.

@saran-t requested this PR after encountering my post about the instability on X.

p.s. My version of the file has additional changes which might be helpful

- The go2-floor contact is way too slippery imo, it looks unrealistic to me. I 5x'ed friction on the feet of the go2 model, since they have higher priority than the floor.
- The tracking camera is too high for me. I set its z coordinate to 0.5 to center the go2 better.

![image](https://github.com/user-attachments/assets/401d753f-9ffa-424c-a321-1f1aad65ffb7)