### PR TITLE
Create `boston_dynamics_spot/scene_arm.xml`

### DIFF
--- a/boston_dynamics_spot/scene_arm.xml
+++ b/boston_dynamics_spot/scene_arm.xml
@@ -1,0 +1,23 @@
+<mujoco model="spot with arm scene">
+  <include file="spot_arm.xml"/>
+
+  <statistic center="0.15 0.1 0.38" extent=".8" meansize="0.05"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="220" elevation="-10"/>
+    <quality shadowsize="8192"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+  </worldbody>
+</mujoco>


### PR DESCRIPTION
Hi,

I'm a maintainer of [Gymnasium](https://gymnasium.farama.org/) & the project manager of [Gymnasium-Robotics](https://robotics.farama.org/), and I'm trying to use `MuJoCo Menagarie` for ["Example of multi-agent factorization"](https://robotics.farama.org/envs/MaMuJoCo/#example-boston-dynamics-spot-arm-with-custom-quadruped-arm-factorization).

Creates a scene for the spot arm, this is useful because I can point to people to the file, rather than explaining how to create the file

the file is derived from `boston_dynamics_spot/scene.xml` and only the first 2 lines were changed