### PR TITLE
Better grasping for xArm7

### DIFF
--- a/ufactory_xarm7/hand.xml
+++ b/ufactory_xarm7/hand.xml
@@ -31,6 +31,18 @@
       <default class="follower">
         <joint solreflimit="0.005 1"/>
       </default>
+      <default class="visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2"/>
+      </default>
+      <default class="collision">
+        <geom type="mesh" group="3"/>
+        <default class="pad_box1">
+          <geom type="box" friction="0.7" solimp="0.95 0.99 0.001" solref="0.004 1" mass="0" priority="1" size="0.015 0.002 0.0095" rgba="0.0 0.1 0.7 1"/>
+        </default>
+        <default class="pad_box2">
+          <geom type="box" friction="0.6" solimp="0.95 0.99 0.001" solref="0.004 1" mass="0" priority="1" size="0.015 0.002 0.0095" rgba="0.0 0.5 0.5 1"/>
+        </default>
+      </default>
     </default>
   </default>
 
@@ -48,7 +60,9 @@
           <inertial pos="0 -0.016413 0.029258" quat="0.697634 0.115353 -0.115353 0.697634" mass="0.048304"
             diaginertia="1.88037e-05 1.7493e-05 3.56792e-06"/>
           <joint name="left_finger_joint" axis="-1 0 0" class="follower"/>
-          <geom material="black" mesh="left_finger"/>
+          <geom class="visual" material="black" mesh="left_finger"/>
+          <geom class="pad_box1" name="left_finger_pad_1" pos="0 -0.024003 0.032"/>
+          <geom class="pad_box2" name="left_finger_pad_2" pos="0 -0.024003 0.050"/>
         </body>
       </body>
       <body name="left_inner_knuckle" pos="0 0.02 0.074098">
@@ -66,7 +80,9 @@
           <inertial pos="0 0.016413 0.029258" quat="0.697634 -0.115356 0.115356 0.697634" mass="0.048304"
             diaginertia="1.88038e-05 1.7493e-05 3.56779e-06"/>
           <joint name="right_finger_joint" class="follower"/>
-          <geom material="black" mesh="right_finger"/>
+          <geom class="visual" material="black" mesh="right_finger"/>
+          <geom class="pad_box1" name="right_finger_pad_1" pos="0 0.024003 0.032"/>
+          <geom class="pad_box2" name="right_finger_pad_2" pos="0 0.024003 0.050"/>
         </body>
       </body>
       <body name="right_inner_knuckle" pos="0 -0.02 0.074098">

--- a/ufactory_xarm7/hand.xml
+++ b/ufactory_xarm7/hand.xml
@@ -19,7 +19,7 @@
   <default>
     <default class="xarm7_hand">
       <geom type="mesh" material="black"/>
-      <joint range="0 0.85" axis="1 0 0" frictionloss="1"/>
+      <joint range="0 0.85" axis="1 0 0" armature="0.1" frictionloss="1"/>
       <site size="0.001" rgba="1 0 0 1" group="4"/>
       <general biastype="affine" forcerange="-50 50" ctrlrange="0 255" gainprm="0.333" biasprm="0 -100 -10"/>
       <default class="spring_link">

--- a/ufactory_xarm7/xarm7.xml
+++ b/ufactory_xarm7/xarm7.xml
@@ -29,7 +29,7 @@
   <default>
     <default class="xarm7">
       <geom type="mesh" material="white"/>
-      <joint axis="0 0 1" range="-6.28319 6.28319" frictionloss="1"/>
+      <joint axis="0 0 1" armature="0.1" range="-6.28319 6.28319" frictionloss="1"/>
       <general biastype="affine" ctrlrange="-6.28319 6.28319"/>
       <default class="size1">
         <joint damping="10"/>

--- a/ufactory_xarm7/xarm7.xml
+++ b/ufactory_xarm7/xarm7.xml
@@ -52,6 +52,18 @@
       <default class="follower">
         <joint range="0 0.85" solreflimit="0.005 1"/>
       </default>
+      <default class="visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2"/>
+      </default>
+      <default class="collision">
+        <geom type="mesh" group="3"/>
+        <default class="pad_box1">
+          <geom type="box" friction="0.7" solimp="0.95 0.99 0.001" solref="0.004 1" mass="0" priority="1" size="0.015 0.002 0.0095" rgba="0.0 0.1 0.7 1"/>
+        </default>
+        <default class="pad_box2">
+          <geom type="box" friction="0.6" solimp="0.95 0.99 0.001" solref="0.004 1" mass="0" priority="1" size="0.015 0.002 0.0095" rgba="0.0 0.5 0.5 1"/>
+        </default>
+      </default>
       <site size="0.001" rgba="1 0 0 1" group="4"/>
     </default>
   </default>
@@ -109,7 +121,9 @@
                           <inertial pos="0 -0.016413 0.029258" quat="0.697634 0.115353 -0.115353 0.697634"
                             mass="0.048304" diaginertia="1.88037e-05 1.7493e-05 3.56792e-06"/>
                           <joint name="left_finger_joint" axis="-1 0 0" class="follower"/>
-                          <geom material="black" mesh="left_finger"/>
+                          <geom class="visual" material="black" mesh="left_finger"/>
+                          <geom class="pad_box1" name="left_finger_pad_1" pos="0 -0.024003 0.032"/>
+                          <geom class="pad_box2" name="left_finger_pad_2" pos="0 -0.024003 0.050"/>
                         </body>
                       </body>
                       <body name="left_inner_knuckle" pos="0 0.02 0.074098">
@@ -127,7 +141,9 @@
                           <inertial pos="0 0.016413 0.029258" quat="0.697634 -0.115356 0.115356 0.697634"
                             mass="0.048304" diaginertia="1.88038e-05 1.7493e-05 3.56779e-06"/>
                           <joint name="right_finger_joint" axis="1 0 0" class="follower"/>
-                          <geom material="black" mesh="right_finger"/>
+                          <geom class="visual" material="black" mesh="right_finger"/>
+                          <geom class="pad_box1" name="right_finger_pad_1" pos="0 0.024003 0.032"/>
+                          <geom class="pad_box2" name="right_finger_pad_2" pos="0 0.024003 0.050"/>
                         </body>
                       </body>
                       <body name="right_inner_knuckle" pos="0 -0.02 0.074098">

--- a/ufactory_xarm7/xarm7_nohand.xml
+++ b/ufactory_xarm7/xarm7_nohand.xml
@@ -21,7 +21,7 @@
   <default>
     <default class="xarm7">
       <geom type="mesh" material="white"/>
-      <joint axis="0 0 1" range="-6.28319 6.28319" frictionloss="1"/>
+      <joint axis="0 0 1" armature="0.1" range="-6.28319 6.28319" frictionloss="1"/>
       <general biastype="affine" ctrlrange="-6.28319 6.28319"/>
       <default class="size1">
         <joint damping="10"/>


### PR DESCRIPTION
# What this does
---

This PR addresses the Graspin issue discussed in #83. The resolution includes the following changes:

- Updated the `xarm7.xml`, `xarm7_nohand.xml`, and `hand.xml` files by adding `armature=0.1` to the xArm7 joints.
- Introduced two collision boxes as pads for each finger.

# How it was tested
---

The changes were verified using the Mink Python library, with results documented in #83.