### PR TITLE
Match frame of UR robots with base frame used by real robot controlbox

### DIFF
--- a/universal_robots_ur10e/ur10e.xml
+++ b/universal_robots_ur10e/ur10e.xml
@@ -68,7 +68,7 @@
 
   <worldbody>
     <light name="spotlight" mode="targetbodycom" target="wrist_2_link" pos="0 -1 2"/>
-    <body name="base" quat="1 0 0 1" childclass="ur10e">
+    <body name="base" quat="0 0 0 -1" childclass="ur10e">
       <inertial mass="4.0" pos="0 0 0" diaginertia="0.0061063308908 0.0061063308908 0.01125"/>
       <geom mesh="base_0" material="black" class="visual"/>
       <geom mesh="base_1" material="jointgray" class="visual"/>

--- a/universal_robots_ur5e/ur5e.xml
+++ b/universal_robots_ur5e/ur5e.xml
@@ -61,7 +61,7 @@
 
   <worldbody>
     <light name="spotlight" mode="targetbodycom" target="wrist_2_link" pos="0 -1 2"/>
-    <body name="base" quat="1 0 0 1" childclass="ur5e">
+    <body name="base" quat="0 0 0 -1" childclass="ur5e">
       <inertial mass="4.0" pos="0 0 0" diaginertia="0.00443333156 0.00443333156 0.0072"/>
       <geom mesh="base_0" material="black" class="visual"/>
       <geom mesh="base_1" material="jointgray" class="visual"/>


### PR DESCRIPTION
This PR changes the orientation of the `base body` of the UR robots to match the frame of the robot with the frame used by a real robot controlbox.  See [the original URDF]() file for reference, where they also added a separate link that corresponds to the real robot base frame.

This ensures that a given joint configuration corresponds to the same pose for a real robot (expressed in the base frame) and a simulated robot (expressed in the 'attachment site' / world frame). This avoids confusion and allows to use real world trajectories/IK tools/... in the simulator.

This PR closes #75.

One thing to note is that there is currently no site/body within the robot model that corresponds to the *actual* base frame. I'm not sure if there is a convention for this within the repository? (@kevinzakka).

Following code snippet can be used to check the poses corresponding to a joint configuration match for a real robot and simulated robot:
```python
    import robot_descriptions
   from dm_control import mjcf

    robot = robot_descriptions.ur5e_mj_description.MJCF_PATH
    robot = mjcf.from_path(robot)
    physics = mjcf.Physics.from_mjcf_model(robot)

    joint_config = np.zeros(6)
    physics.bind(robot.find_all("joint")).qpos = joint_config
    
    # get attachment site pose
    attachment_site = robot.find("site", "attachment_site")
    attachment_site_pose = physics.bind(attachment_site).xpos
    attachment_site_orientation = physics.bind(attachment_site).xmat.reshape(3,3)
    pose = np.eye(4)
    pose[:3, :3] = attachment_site_orientation
    pose[:3, 3] = attachment_site_pose
    print(f"attachment site pose: \r\n {pose}")

    # get real robot pose for same joint config
    # ur_analytic_ik has been validated to match the base frame used by real robot controlboxes
    import ur_analytic_ik
    FK_pose = ur_analytic_ik.ur5e.forward_kinematics(*joint_config)
    print(f"forward kinematics pose: \r\n {FK_pose}")

```
