### PR TITLE
Corrects minor typo in Spot README

### DIFF
--- a/boston_dynamics_spot/README.md
+++ b/boston_dynamics_spot/README.md
@@ -8,13 +8,13 @@
 This package contains a simplified robot description (MJCF) of the [Spot
 Quadruped](https://bostondynamics.com/products/spot/) developed by [Boston
 Dynamics](https://bostondynamics.com/). It is derived from the [publicly
-available MJCF description](https://github.com/bdaiinstitute/spot_ros2).
+available URDF description](https://github.com/bdaiinstitute/spot_ros2).
 
 <p float="left">
   <img src="spot.png" width="400">
 </p>
 
-## MJCF derivation steps
+## URDF → MJCF Conversion
 
 1. Processed `.obj` files with [`obj2mjcf`](https://github.com/kevinzakka/obj2mjcf).
 2. Added `<mujoco> <compiler discardvisual="false" strippath="false" fusestatic="false"/> </mujoco>` to the URDF's


### PR DESCRIPTION
This PR fixes a minor typo in the Spot README. The previous wording implied that an MJCF model was already present in the BDAII repository, whereas only a URDF description file exists.