### PR TITLE
Update all changelog dates to use YYYY-MM-dd format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 All notable changes to this repository will be documented here.
 
-## [30/05/2025]
+## [2025-05-30]
 
 - Added an MJX-tuned version of the G1 model.
 
-## [19/05/2025]
+## [2025-05-19]
 
 - Added [YAM manipulator](i2rt_yam/README.md) from I2RT Robotics.
 
-## [22/04/2025]
+## [2025-04-22]
 
 - Adds changelog structure, contributor list, and PR template.
 
-## [07/09/2022]
+## [2022-09-07]
 
 - Initial release.

--- a/agilex_piper/CHANGELOG.md
+++ b/agilex_piper/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [16/02/2025]
+## [2025-02-16]
 - Initial release.

--- a/agility_cassie/CHANGELOG.md
+++ b/agility_cassie/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/aloha/CHANGELOG.md
+++ b/aloha/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/02/2024]
+## [2024-02-05]
 - Initial release.

--- a/anybotics_anymal_b/CHANGELOG.md
+++ b/anybotics_anymal_b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/anybotics_anymal_c/CHANGELOG.md
+++ b/anybotics_anymal_c/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/apptronik_apollo/CHANGELOG.md
+++ b/apptronik_apollo/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/02/2025]
+## [2025-05-02]
 - Changed acuator order to match joint order and moved kv to damping for better
 sim2real transfer.
 
-## [04/17/2025]
+## [2025-04-17]
 - IMU position correction based on Apptroink request.
 
-## [03/15/2025]
+## [2025-03-15]
 - Fixed finger distal orientation.
 
-## [01/21/2025]
+## [2025-01-21]
 - Fixed bug in the IMU position.
 
-## [01/09/2025]
+## [2025-01-09]
 - Fixed issue https://github.com/google-deepmind/mujoco_menagerie/issues/136.
 
-## [12/20/2024]
+## [2024-12-20]
 - Initial release.

--- a/arx_l5/CHANGELOG.md
+++ b/arx_l5/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [20/03/2025]
+## [2025-03-20]
 - Initial release.

--- a/berkeley_humanoid/CHANGELOG.md
+++ b/berkeley_humanoid/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/12/2024]
+## [2024-12-06]
 - Initial release.

--- a/bitcraze_crazyflie_2/CHANGELOG.md
+++ b/bitcraze_crazyflie_2/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [03/03/2024]
+## [2024-03-03]
 - Initial release.

--- a/booster_t1/CHANGELOG.md
+++ b/booster_t1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/02/2025]
+## [2025-02-07]
 - Initial release.

--- a/boston_dynamics_spot/CHANGELOG.md
+++ b/boston_dynamics_spot/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [31/05/2024]
+## [2024-05-31]
 - Initial release.

--- a/flybody/CHANGELOG.md
+++ b/flybody/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [19/04/2024]
+## [2024-04-19]
 - Initial release.

--- a/fourier_n1/CHANGELOG.md
+++ b/fourier_n1/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/05/2025]
+## [2025-05-05]
 
 - Initial release.

--- a/franka_emika_panda/CHANGELOG.md
+++ b/franka_emika_panda/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/franka_fr3/CHANGELOG.md
+++ b/franka_fr3/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this model will be documented in this file.
 
-## [25/04/2025]
+## [2025-04-25]
 - Update armature, damping, friction parameters, identified in torque control.
 
-## [31/05/2024]
+## [2024-05-31]
 - Initial release.

--- a/google_barkour_v0/CHANGELOG.md
+++ b/google_barkour_v0/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2023]
+## [2023-09-07]
 - Initial release.

--- a/google_barkour_vb/CHANGELOG.md
+++ b/google_barkour_vb/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [24/10/2023]
+## [2023-10-24]
 - Initial release.

--- a/google_robot/CHANGELOG.md
+++ b/google_robot/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/10/2023]
+## [2023-10-06]
 - Initial release.

--- a/hello_robot_stretch/CHANGELOG.md
+++ b/hello_robot_stretch/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/09/2023]
+## [2023-09-05]
 - Initial release.

--- a/hello_robot_stretch_3/CHANGELOG.md
+++ b/hello_robot_stretch_3/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [28/06/2024]
+## [2024-06-28]
 - Initial release.

--- a/i2rt_yam/CHANGELOG.md
+++ b/i2rt_yam/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 All notable changes to this model will be documented in this file.
 
-## [19/05/2025]
+## [2025-05-19]
 
 - Initial release.

--- a/kinova_gen3/CHANGELOG.md
+++ b/kinova_gen3/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [28/06/2024]
+## [2024-06-28]
 - Initial release.

--- a/kuka_iiwa_14/CHANGELOG.md
+++ b/kuka_iiwa_14/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.

--- a/leap_hand/CHANGELOG.md
+++ b/leap_hand/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/02/2025]
+## [2025-02-06]
 - Updated appearance of both hand models.
 
-## [06/09/2024]
+## [2024-09-06]
 - Initial release.

--- a/pal_talos/CHANGELOG.md
+++ b/pal_talos/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/09/2024]
+## [2024-09-06]
 - Initial release.

--- a/pal_tiago/CHANGELOG.md
+++ b/pal_tiago/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/09/2024]
+## [2024-09-06]
 - Initial release.

--- a/pal_tiago_dual/CHANGELOG.md
+++ b/pal_tiago_dual/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/09/2024]
+## [2024-09-06]
 - Initial release.

--- a/realsense_d435i/CHANGELOG.md
+++ b/realsense_d435i/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.

--- a/rethink_robotics_sawyer/CHANGELOG.md
+++ b/rethink_robotics_sawyer/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.

--- a/robotiq_2f85/CHANGELOG.md
+++ b/robotiq_2f85/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/robotiq_2f85_v4/CHANGELOG.md
+++ b/robotiq_2f85_v4/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [02/12/2024]
+## [2024-12-02]
 - Initial release.

--- a/robotis_op3/CHANGELOG.md
+++ b/robotis_op3/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.

--- a/shadow_dexee/CHANGELOG.md
+++ b/shadow_dexee/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/06/2024]
+## [2024-07-12]
 - Initial release.

--- a/shadow_hand/CHANGELOG.md
+++ b/shadow_hand/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/skydio_x2/CHANGELOG.md
+++ b/skydio_x2/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [11/09/2023]
+## [2023-09-11]
 - Initial release.

--- a/stanford_tidybot/CHANGELOG.md
+++ b/stanford_tidybot/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [09/09/2024]
+## [2024-09-09]
 - Initial release.

--- a/trossen_vx300s/CHANGELOG.md
+++ b/trossen_vx300s/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [05/12/2023]
+## [2023-12-05]
 - Initial release.

--- a/trossen_wx250s/CHANGELOG.md
+++ b/trossen_wx250s/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [04/06/2024]
+## [2024-06-04]
 - Initial release.

--- a/trs_so_arm100/CHANGELOG.md
+++ b/trs_so_arm100/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
-## [09/06/2025]
+## [2025-06-09]
 - Adjusted joint limits to match real robot's physical constraints.
 - Changed primary color of robot to white.
 - Added rest position keyframe.
 
-## [25/11/2024]
+## [2024-11-25]
 - Initial release.

--- a/ufactory_lite6/CHANGELOG.md
+++ b/ufactory_lite6/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [03/11/2023]
+## [2023-11-03]
 - Initial release.

--- a/ufactory_xarm7/CHANGELOG.md
+++ b/ufactory_xarm7/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
-## [17/12/2024]
+## [2024-12-17]
 - Improved object grasping (thanks to [@s1lent4gnt](https://github.com/s1lent4gnt)) by:
     - Adding two collision box meshes as pads for each finger.
     - Setting `armature=0.1` for the joints.
 
-## [24/08/2023]
+## [2023-08-24]
 - Initial release.

--- a/umi_gripper/CHANGELOG.md
+++ b/umi_gripper/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [28/10/2024]
+## [2024-10-28]
 - Initial release.

--- a/unitree_a1/CHANGELOG.md
+++ b/unitree_a1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/unitree_g1/CHANGELOG.md
+++ b/unitree_g1/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this model will be documented in this file.
 
-## [30/05/25]
+## [2025-05-30]
 
 - Add MJX variant of [g1.xml](g1.xml), with manually designed collision geoms and contact pairs.
 
@@ -10,12 +10,12 @@ All notable changes to this model will be documented in this file.
   <img src="g1_mjx_colliders.png" width="400">
 </p>
 
-## [10/12/2024]
+## [2024-12-10]
 
 - Use updated models from Unitree's official [repo](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/g1_description) (sha: c20ca8f1fe5e519474c6c8d10b1ce5c719dd7a65).
   - Model without hands: [g1_29dof_rev_1_0](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/g1_description/g1_29dof_rev_1_0.xml)
   - Model with hands: [g1_29dof_with_hand_rev_1_0](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/g1_description/g1_29dof_with_hand_rev_1_0.xml)
 
-## [20/05/2024]
+## [2024-05-20]
 
 - Initial release.

--- a/unitree_go1/CHANGELOG.md
+++ b/unitree_go1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.

--- a/unitree_go2/CHANGELOG.md
+++ b/unitree_go2/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this model will be documented in this file.
 
-## [16/02/2025]
+## [2025-02-16]
 - Make actuator order match joint order.
 
-## [01/06/2024]
+## [2024-06-01]
 - Fix foot solimp.
 
-## [23/10/2023]
+## [2023-10-23]
 - Initial release.

--- a/unitree_h1/CHANGELOG.md
+++ b/unitree_h1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [06/11/2023]
+## [2023-11-06]
 - Initial release.

--- a/unitree_z1/CHANGELOG.md
+++ b/unitree_z1/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [14/12/2023]
+## [2023-12-14]
 - Initial release.

--- a/universal_robots_ur10e/CHANGELOG.md
+++ b/universal_robots_ur10e/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [07/09/2022]
+## [2022-09-07]
 - Initial release.

--- a/universal_robots_ur5e/CHANGELOG.md
+++ b/universal_robots_ur5e/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [01/03/2023]
+## [2022-09-07]
 - Initial release.

--- a/wonik_allegro/CHANGELOG.md
+++ b/wonik_allegro/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this model will be documented in this file.
 
-## [18/05/2023]
+## [2023-05-18]
 - Initial release.


### PR DESCRIPTION
Update all changelog dates to use YYYY-MM-dd format.

Some dates were in dd/MM/YYYY, and some in MM/dd/YYYY.

This was done by Gemini (with my help). To determine the correct date format, it used the following heuristics:
- If there is any mm or dd number > 12, assume all dates are in the same format.
- If the date can be resolved by the order of entries, do that.
- Lookup the first commit date of each directory and check that the initial release date matches what's in the changelog (I had to manually fix shadow_dexee and ur5e).
