### PR TITLE
Add explicit contact excludes between base and first link of Panda and FR3.

### DIFF
--- a/franka_emika_panda/CHANGELOG.md
+++ b/franka_emika_panda/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2025-07-02]
+- Explicitly exclude contacts between the base and the first link.
+
 ## [2022-09-07]
 - Initial release.

--- a/franka_emika_panda/mjx_panda.xml
+++ b/franka_emika_panda/mjx_panda.xml
@@ -273,4 +273,8 @@
     <general class="panda" name="actuator8" joint="finger_joint1"
      ctrlrange="0 0.04" gainprm="350 0 0" biasprm="0 -350 -10" forcerange="-200 200"/>
   </actuator>
+
+  <contact>
+    <exclude body1="link0" body2="link1"/>
+  </contact>
 </mujoco>

--- a/franka_emika_panda/mjx_panda_nohand.xml
+++ b/franka_emika_panda/mjx_panda_nohand.xml
@@ -208,4 +208,8 @@
       ctrlrange="-0.0175 3.7525"/>
     <position class="panda" name="actuator7" joint="joint7" kp="300" kv="2" forcerange="-12 12"/>
   </actuator>
+
+  <contact>
+    <exclude body1="link0" body2="link1"/>
+  </contact>
 </mujoco>

--- a/franka_emika_panda/panda.xml
+++ b/franka_emika_panda/panda.xml
@@ -280,4 +280,8 @@
   <keyframe>
     <key name="home" qpos="0 0 0 -1.57079 0 1.57079 -0.7853 0.04 0.04" ctrl="0 0 0 -1.57079 0 1.57079 -0.7853 255"/>
   </keyframe>
+
+  <contact>
+    <exclude body1="link0" body2="link1"/>
+  </contact>
 </mujoco>

--- a/franka_emika_panda/panda_nohand.xml
+++ b/franka_emika_panda/panda_nohand.xml
@@ -211,6 +211,10 @@
     <general class="panda" name="actuator7" joint="joint7" gainprm="2000" biasprm="0 -2000 -200" forcerange="-12 12"/>
   </actuator>
 
+  <contact>
+    <exclude body1="link0" body2="link1"/>
+  </contact>
+
   <keyframe>
     <key name="home" qpos="0 0 0 -1.57079 0 1.57079 -0.7853" ctrl="0 0 0 -1.57079 0 1.57079 -0.7853"/>
   </keyframe>

--- a/franka_fr3/CHANGELOG.md
+++ b/franka_fr3/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2025-07-02]
+- Explicitly exclude contacts between the base and the first link, in `fr3.xml`, to match `fr3_mjx.xml`.
+
 ## [2025-04-25]
 - Update armature, damping, friction parameters, identified in torque control.
 

--- a/franka_fr3/fr3.xml
+++ b/franka_fr3/fr3.xml
@@ -158,6 +158,10 @@
     <position class="fr3" name="fr3_joint7" joint="fr3_joint7" kp="2000" kv="200"/>
   </actuator>
 
+  <contact>
+    <exclude body1="fr3_link0" body2="fr3_link1"/>
+  </contact>
+
   <keyframe>
     <key name="home" qpos="0 0 0 -1.57079 0 1.57079 -0.7853" ctrl="0 0 0 -1.57079 0 1.57079 -0.7853"/>
   </keyframe>


### PR DESCRIPTION
Add explicit contact excludes between base and first link of Panda and FR3.

Normally in MuJoCo, contacts between a body and its parent are automatically excluded, but this isn't true if the parent is a static body (welded to the worldbody)
