### PR TITLE
Fix collision size for shoulder_link in ur10e.xml, line 81.

### DIFF
--- a/universal_robots_ur10e/ur10e.xml
+++ b/universal_robots_ur10e/ur10e.xml
@@ -78,7 +78,7 @@
         <geom mesh="shoulder_0" material="urblue" class="visual"/>
         <geom mesh="shoulder_1" material="black" class="visual"/>
         <geom mesh="shoulder_2" material="jointgray" class="visual"/>
-        <geom class="collision" size="0.078 0.08" pos="0 0 -0.05"/>
+        <geom class="collision" size="0.078 0.05" pos="0 0 -0.02"/>
         <body name="upper_arm_link" pos="0 0.176 0" quat="1 0 1 0">
           <inertial pos="0 0 0.3065" mass="12.93" diaginertia="0.423074 0.423074 0.0363656"/>
           <joint name="shoulder_lift_joint" class="size4"/>


### PR DESCRIPTION
# Description

Wrong collision size for shoulder_link leads to an erroneous collision detection with the ground, generating large contact forces and causing instability in the simulation environment. 

Fixes: <!-- List any GitHub issues this PR addresses -->
#192 
# Checklist

Please check off each item (`[x]`) once complete, or mark it as `[N/A]` if it doesn't apply:

- [N/A] Added your name to `CONTRIBUTORS.md` (alphabetically by first name)
- [N/A] Updated `CHANGELOG.md`:
  - [N/A] Global changelog (if your change affects the overall repo)
  - [N/A] Model-specific changelog (if it affects a specific model only)
- [x] Followed the XML formatting/style guidelines (if editing MJCF)
- [x] Ran `pytest test/` locally and ensured all tests pass
- [x] Signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/)

Refer to the [contributing guide](https://github.com/google-deepmind/mujoco_menagerie/blob/main/CONTRIBUTING.md) if you're unsure about any of the steps.
