### PR TITLE
Fix LEAP Hand's `left_hand.xml` thumb_cmc range

### DIFF
--- a/leap_hand/CHANGELOG.md
+++ b/leap_hand/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2025-09-04]
+- Fixed Left Leap Hand's Thumb CMC range
+
 ## [2025-02-06]
 - Updated appearance of both hand models.
 

--- a/leap_hand/left_hand.xml
+++ b/leap_hand/left_hand.xml
@@ -128,7 +128,7 @@ Naming Conventions
       <position ctrlrange="-0.366 2.042" />
     </default>
     <default class="thumb_cmc">
-      <joint pos="0 0 0" axis="0 0 -1"
+      <joint pos="0 0 0" axis="0 0 1"
         limited="true" range="-0.349 2.094" />
       <position ctrlrange="-0.349 2.094" />
     </default>


### PR DESCRIPTION
Hi,

This is a quick fix for the left LEAP Hand's `thumb_cmc` joint ctrl range. The joint behaves correctly now ✅
<img width="2033" height="1595" alt="image" src="https://github.com/user-attachments/assets/4abca95c-2878-46f1-8248-2a2b4bdf769a" />
