### PR TITLE
Fix base collision alignment and pad mass in robotiq_2f85_v4

### DIFF
--- a/robotiq_2f85_v4/2f85.xml
+++ b/robotiq_2f85_v4/2f85.xml
@@ -45,11 +45,11 @@
       <default class="collision">
         <geom type="mesh" group="3"/>
         <default class="pad_box1">
-          <geom mass="1e-6" type="box" pos="0.043258  0 0.12"  size="0.002 0.011 0.009375" friction="0.7"
+          <geom mass="0.00175" type="box" pos="0.043258  0 0.12"  size="0.002 0.011 0.009375" friction="0.7"
             solimp="0.95 0.99 0.001" solref="0.004 1" priority="1" rgba="0.55 0.55 0.55 1"/>
         </default>
         <default class="pad_box2">
-          <geom mass="1e-6" type="box" pos="0.043258 0 0.13875" size="0.002 0.011 0.009375" friction="0.6"
+          <geom mass="0.00175" type="box" pos="0.043258 0 0.13875" size="0.002 0.011 0.009375" friction="0.6"
             solimp="0.95 0.99 0.001" solref="0.004 1" priority="1" rgba="0.45 0.45 0.45 1"/>
         </default>
       </default>

--- a/robotiq_2f85_v4/2f85.xml
+++ b/robotiq_2f85_v4/2f85.xml
@@ -65,7 +65,7 @@
       <geom class="visual" pos="0 0 0.0108" quat="0 0 0 1"   mesh="base"/>
       <geom class="visual" pos="0 0 0.004" quat="1 -1 0 0"   mesh="base_coupling"/>
       <geom class="visual" pos="0 0 0.0108" quat="1 0 0 0"  material="metal" mesh="c-a01-85-open"/>
-      <geom class="collision" mesh="base"/>
+      <geom class="collision" pos="0 0 0.0108" quat="0 0 0 1" mesh="base"/>
       <!-- Left-hand side 4-bar linkage -->
       <body name="left_driver" pos="-0.0306011 0.00475 0.0657045" quat="1 -1 0 0">
         <inertial mass="0.00899563" pos="-0.0175297 0.00165308 -0.00469625"

--- a/robotiq_2f85_v4/CHANGELOG.md
+++ b/robotiq_2f85_v4/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2026-04-13]
+- Fix base collision geom alignment (missing `pos` and `quat` attributes).
+- Fix pad geom masses: set each pad geom to 1.75 g so each pad body totals 3.5 g, matching the original `robotiq_2f85` model.
+
 ## [2024-12-02]
 - Initial release.


### PR DESCRIPTION
## Summary

Two fixes for the `robotiq_2f85_v4` model:

### 1. Base collision geom misalignment (bug fix)

The visual base geom has `pos="0 0 0.0108" quat="0 0 0 1"` but the collision base geom has neither attribute, so the collision mesh sits at the body origin while the visual is offset and rotated. This PR copies the visual geom's `pos` and `quat` to the collision geom.

https://github.com/user-attachments/assets/e6156a10-d300-40be-9e03-79f03f334f21

https://github.com/user-attachments/assets/10c01392-fab8-4b38-b7d4-9cc6c535f00a

### 2. Pad geom masses (question + fix)

The pad_box1 and pad_box2 default classes use `mass="1e-6"` (~0.001 g), giving each pad body a total mass of ~0.002 g. The original `robotiq_2f85` model specifies 3.5 g per pad body.

The V4 README states "Used inertia and mass from robotiq_2f85 model", so this looks like an oversight. This PR sets each pad geom to 1.75 g (0.00175 kg) so the two geoms per body sum to 3.5 g (0.0035 kg).

**Question for maintainers:** Was the near-zero pad mass intentional for the V4 model, or is this an oversight from the URDF-to-MJCF conversion? Has any system identification work been done for the V4 gripper that would inform the correct pad mass?

## Testing

- Verified visual/collision alignment in `mujoco.viewer`
- Verified gripper still closes and grasps the scene's hanging box