### PR TITLE
Add gravcomp to Flexiv Rizon4 arm links to fix position tracking errors

### DIFF
--- a/flexiv_rizon4/flexiv_rizon4.xml
+++ b/flexiv_rizon4/flexiv_rizon4.xml
@@ -43,43 +43,43 @@
     <light name="top" pos="0 0 2" mode="trackcom"/>
     <body name="base" childclass="Rizon4">
       <geom name="convex_mesh" mesh="link0"/>
-      <body name="link1" pos="0 0 0.155" quat="0 0 0 1">
+      <body name="link1" pos="0 0 0.155" quat="0 0 0 1" gravcomp="1">
         <inertial pos="0.0001 0.0035 0.15" quat="0.999632 0.0271175 0 0" mass="3.596"
           diaginertia="0.0274 0.0273597 0.00704028"/>
         <joint name="joint1" axis="0 0 1" range="-2.8798 2.8798" class="joint1"/>
         <geom mesh="link1_0" material="cover"/>
         <geom mesh="link1_1"/>
-        <body name="link2" pos="0 0.03 0.21">
+        <body name="link2" pos="0 0.03 0.21" gravcomp="1">
           <inertial pos="-0.0003 0.0361 0.0998" quat="0.707105 -0.00174158 0.00174158 0.707105" mass="2.69"
             diaginertia="0.0239005 0.023 0.00359951"/>
           <joint name="joint2" axis="0 1 0" range="-2.3562 2.3562" class="joint1"/>
           <geom mesh="link2_0"/>
           <geom mesh="link2_1" material="cover"/>
-          <body name="link3" pos="0 0.035 0.205">
+          <body name="link3" pos="0 0.035 0.205" gravcomp="1">
             <inertial pos="-0.0123 -0.0012 0.1366" quat="0.991949 -0.0168831 0.0724717 0.102468" mass="2.354"
               diaginertia="0.0145488 0.0136885 0.00376272"/>
             <joint name="joint3" axis="0 0 1" range="-3.0543 3.0543" class="joint2"/>
             <geom mesh="link3_0"/>
             <geom mesh="link3_1" material="cover"/>
-            <body name="link4" pos="-0.02 -0.03 0.19" quat="0 0 0 1">
+            <body name="link4" pos="-0.02 -0.03 0.19" quat="0 0 0 1" gravcomp="1">
               <inertial pos="-0.0129 0.0313 0.1034" quat="0.850968 -0.00510153 0.0639413 0.521285" mass="2.354"
                 diaginertia="0.0186051 0.0180531 0.00274185"/>
               <joint name="joint4" axis="0 1 0" range="-1.9548 2.7751" class="joint2"/>
               <geom mesh="link4_0" material="cover"/>
               <geom mesh="link4_1"/>
-              <body name="link5" pos="-0.02 0.025 0.195" quat="0 0 0 1">
+              <body name="link5" pos="-0.02 0.025 0.195" quat="0 0 0 1" gravcomp="1">
                 <inertial pos="0.0003 0.0014 0.1363" quat="0.999677 0.0254195 0 0" mass="2.31"
                   diaginertia="0.0142 0.0135254 0.00367456"/>
                 <joint name="joint5" axis="0 0 1" range="-3.0543 3.0543" class="joint3"/>
                 <geom mesh="link5_0"/>
                 <geom mesh="link5_1" material="cover"/>
-                <body name="link6" pos="0 0.03 0.19">
+                <body name="link6" pos="0 0.03 0.19" gravcomp="1">
                   <inertial pos="0.0202 0.0596 0.0724" quat="0.858167 0.0778802 -0.159016 0.481869" mass="2.223"
                     diaginertia="0.0100226 0.00828177 0.00339567"/>
                   <joint name="joint6" axis="0 1 0" range="-1.4835 4.6251" class="joint3"/>
                   <geom mesh="link6_0"/>
                   <geom mesh="link6_1" material="cover"/>
-                  <body name="link7" pos="-0.015 0.073 0.11" quat="0.707107 0 -0.707107 0">
+                  <body name="link7" pos="-0.015 0.073 0.11" quat="0.707107 0 -0.707107 0" gravcomp="1">
                     <inertial pos="0.0003 0 0.0257" mass="0.768" diaginertia="0.001 0.0009 0.0009"/>
                     <joint name="joint7" axis="0 0 1" range="-3.0543 3.0543" class="joint3"/>
                     <geom mesh="link7"/>


### PR DESCRIPTION
The Flexiv Rizon4 position actuators exhibited steady-state tracking errors: commanding joint4 to 1.57 rad resulted in a real angle of ~1.63 rad, and joint2 showed ~0.04 rad undershoot. The root cause is that the real Rizon4 robot has internal gravity compensation, but the MuJoCo model's link bodies lacked `gravcomp="1"`, forcing the PD actuators to fight gravity at every non-zero configuration. This causes configuration-dependent steady-state offsets proportional to the gravitational torque at each joint.

The fix adds `gravcomp="1"` to all seven arm links (link1–link7) in `flexiv_rizon4/flexiv_rizon4.xml`, matching the convention used by other robot models in the repository (e.g., `agilex_piper`, `google_robot`). With gravity compensation enabled, the PD gains computed by `compute_gains.py` now only need to handle dynamic tracking, not steady-state gravitational load, eliminating the position offsets.

Fixes #251
