### PR TITLE
Fix duplicate word typo "the the" in umi_gripper README

### DIFF
--- a/umi_gripper/README.md
+++ b/umi_gripper/README.md
@@ -22,7 +22,7 @@ This model was contributed by Omar Rayyan (@omarrayyann).
 
 ### SOLIDWORKS -> URDF -> MJCF derivation step
 
-1. Converted the the CAD model provided [(here)](https://docs.google.com/document/d/1TPYwV9sNVPAi0ZlAupDMkXZ4CA1hsZx7YDMSmcEy6EU/edit?tab=t.0) to the URDF format using [this](http://wiki.ros.org/sw_urdf_exporter) SolidWorks add-in.
+1. Converted the CAD model provided [(here)](https://docs.google.com/document/d/1TPYwV9sNVPAi0ZlAupDMkXZ4CA1hsZx7YDMSmcEy6EU/edit?tab=t.0) to the URDF format using [this](http://wiki.ros.org/sw_urdf_exporter) SolidWorks add-in.
 2.  Added `<mujoco> <compiler balanceinertia="true" discardvisual="false"/> </mujoco>` to the URDF's
    `<robot>` clause in order to preserve visual geometries.
 3. Loaded the URDF into MuJoCo and saved a corresponding MJCF.


### PR DESCRIPTION
The umi_gripper/README.md contains a duplicated article 'the the' in the SOLIDWORKS -> URDF -> MJCF derivation steps section (step 1). The phrase reads 'Converted the the CAD model provided ...'. This is a clean, unambiguous typo: one of the two 'the' tokens should be removed. The change is purely cosmetic, has zero functional impact on the model, and matches the wording style of every other model README in the repository (e.g. anybotics_anymal_b step 1 reads 'Converted the DAE mesh files ...'). Note: a near-identical typo also exists in agilex_piper/README.md line 23; this PR scopes only the umi_gripper fix to keep the change minimal and reviewable.

---
*Generated by RL PR Hunter*