### PR TITLE
Regenerate aloha/*.patch against reformatted XMLs

### DIFF
--- a/aloha/mjx_aloha.patch
+++ b/aloha/mjx_aloha.patch
@@ -1,18 +1,19 @@
---- aloha.xml	2024-07-24 11:38:17.000000000 -0700
-+++ mjx_aloha.xml	2024-09-25 11:33:18.000000000 -0700
-@@ -1,7 +1,11 @@
+--- aloha.xml
++++ mjx_aloha.xml
+@@ -1,8 +1,12 @@
  <mujoco model="aloha">
    <compiler angle="radian" meshdir="assets" autolimits="true"/>
  
 -  <option cone="elliptic" impratio="10"/>
 +  <option impratio="5"/>
-+
+ 
 +  <visual>
 +    <scale contactwidth="0.075" contactheight="0.025" forcewidth="0.05"/>
 +  </visual>
- 
++
    <asset>
      <material name="black" rgba="0.15 0.15 0.15 1"/>
+ 
 @@ -21,6 +25,7 @@
    </asset>
  
@@ -43,77 +44,85 @@
            <geom type="sphere" size="0.0006" rgba="1 0 0 1"/>
          </default>
 +        <default class="primitive_collision">
-+          <geom contype="0" conaffinity="1" rgba="1 0 0 0.5" group="3"
-+           condim="3" solref="0.01 1" friction="1 0.005 0.0001"/>
++          <geom contype="0" conaffinity="1" rgba="1 0 0 0.5" group="3" condim="3" solref="0.01 1"
++            friction="1 0.005 0.0001"/>
 +        </default>
        </default>
      </default>
    </default>
-@@ -149,6 +161,7 @@
-                     <geom class="collision" pos="0 -0.03525 -0.0227" quat="0 -1 0 -1" type="mesh" mesh="vx300s_7_gripper_wrist_mount"/>
-                     <geom class="visual" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh" mesh="d405_solid"/>
-                     <geom class="collision" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh" mesh="d405_solid"/>
-+                    <geom class="primitive_collision" type="capsule" fromto="0.055 0 0.015 -0.055 0 0.015" size="0.03" />
+@@ -153,6 +165,7 @@
+                       mesh="d405_solid"/>
+                     <geom class="collision" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh"
+                       mesh="d405_solid"/>
++                    <geom class="primitive_collision" type="capsule" fromto="0.055 0 0.015 -0.055 0 0.015" size="0.03"/>
                      <camera name="wrist_cam_left" pos="0 -0.0824748 -0.0095955" mode="fixed" euler="2.70525955359 0 0"
-                             focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"/>
-                    <body name="left/left_finger_link" pos="0.0191 -0.0141637 0.0211727" quat="1 -1 -1 1">
-@@ -157,8 +170,10 @@
+                       focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"/>
+                     <body name="left/left_finger_link" pos="0.0191 -0.0141637 0.0211727" quat="1 -1 -1 1">
+@@ -161,8 +174,12 @@
                        <joint name="left/left_finger" class="left_finger"/>
                        <geom pos="0.0141637 0.0211727 0.06" class="visual" quat="1 1 1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_left"/>
 -                      <geom pos="0.0141637 0.0211727 0.06" class="collision" quat="1 1 1 -1" type="mesh"
 +                      <geom pos="0.0141637 0.0211727 0.06" class="finger_collision" quat="1 1 1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_left"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01  -0.0192 0.015 0.015  -0.0852 0.0228" class="primitive_collision"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035  -0.0192 0.015 0.02  -0.0852 0.0228" class="primitive_collision"/>
-                       <geom name="left/left_g0" pos="0.013  -0.0892 0.0268" class="sphere_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01 -0.0192 0.015 0.015 -0.0852 0.0228"
++                        class="primitive_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035 -0.0192 0.015 0.02 -0.0852 0.0228"
++                        class="primitive_collision"/>
+                       <geom name="left/left_g0" pos="0.013 -0.0892 0.0268" class="sphere_collision"/>
                        <geom name="left/left_g1" pos="0.0222 -0.0892 0.0268" class="sphere_collision"/>
                        <geom name="left/left_g2" pos="0.0182 -0.0845 0.0266" class="sphere_collision"/>
-@@ -170,8 +185,10 @@
+@@ -174,8 +191,12 @@
                        <joint name="left/right_finger" class="right_finger"/>
                        <geom pos="0.0141637 -0.0211727 0.0597067" class="visual" quat="1 -1 -1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_right"/>
 -                      <geom pos="0.0141637 -0.0211727 0.0597067" class="collision" quat="1 -1 -1 -1" type="mesh"
 +                      <geom pos="0.0141637 -0.0211727 0.0597067" class="finger_collision" quat="1 -1 -1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_right"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01  0.0192 0.015 0.015  0.0852 0.0228" class="primitive_collision"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035  -0.0192 0.015 0.02  0.0852 0.0228" class="primitive_collision"/>
-                       <geom name="left/right_g0" pos="0.013  0.0892 0.0268" class="sphere_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01 0.0192 0.015 0.015 0.0852 0.0228"
++                        class="primitive_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035 -0.0192 0.015 0.02 0.0852 0.0228"
++                        class="primitive_collision"/>
+                       <geom name="left/right_g0" pos="0.013 0.0892 0.0268" class="sphere_collision"/>
                        <geom name="left/right_g1" pos="0.0222 0.0892 0.0268" class="sphere_collision"/>
                        <geom name="left/right_g2" pos="0.0182 0.0845 0.0266" class="sphere_collision"/>
-@@ -237,6 +254,7 @@
-                     <geom class="collision" pos="0 -0.03525 -0.0227" quat="0 -0.707107 0 -0.707107" type="mesh" mesh="vx300s_7_gripper_wrist_mount"/>
-                     <geom class="visual" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh" mesh="d405_solid"/>
-                     <geom class="collision" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh" mesh="d405_solid"/>
-+                    <geom class="primitive_collision" type="capsule" fromto="0.055 0 0.015 -0.055 0 0.015" size="0.03" />
+@@ -245,6 +266,7 @@
+                       mesh="d405_solid"/>
+                     <geom class="collision" pos="0 -0.0824748 -0.0095955" quat="0 0 -0.21644 -0.976296" type="mesh"
+                       mesh="d405_solid"/>
++                    <geom class="primitive_collision" type="capsule" fromto="0.055 0 0.015 -0.055 0 0.015" size="0.03"/>
                      <camera name="wrist_cam_right" pos="0 -0.0824748 -0.0095955" mode="fixed" euler="2.70525955359 0 0"
-                             focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"/>
+                       focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"/>
                      <body name="right/left_finger_link" pos="0.0191 -0.0141637 0.0211727" quat="1 -1 -1 1">
-@@ -245,8 +263,10 @@
+@@ -253,8 +275,12 @@
                        <joint name="right/left_finger" class="left_finger"/>
                        <geom pos="0.0141637 0.0211727 0.06" class="visual" quat="1 1 1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_left"/>
 -                      <geom pos="0.0141637 0.0211727 0.06" class="collision" quat="1 1 1 -1" type="mesh"
 +                      <geom pos="0.0141637 0.0211727 0.06" class="finger_collision" quat="1 1 1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_left"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01  -0.0192 0.015 0.015  -0.0852 0.0228" class="primitive_collision"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035  -0.0192 0.015 0.02  -0.0852 0.0228" class="primitive_collision"/>
-                       <geom name="right/left_g0" pos="0.013  -0.0892 0.0268" class="sphere_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01 -0.0192 0.015 0.015 -0.0852 0.0228"
++                        class="primitive_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035 -0.0192 0.015 0.02 -0.0852 0.0228"
++                        class="primitive_collision"/>
+                       <geom name="right/left_g0" pos="0.013 -0.0892 0.0268" class="sphere_collision"/>
                        <geom name="right/left_g1" pos="0.0222 -0.0892 0.0268" class="sphere_collision"/>
                        <geom name="right/left_g2" pos="0.0182 -0.0845 0.0266" class="sphere_collision"/>
-@@ -258,8 +278,10 @@
+@@ -266,8 +292,12 @@
                        <joint name="right/right_finger" class="right_finger"/>
                        <geom pos="0.0141637 -0.0211727 0.0597067" class="visual" quat="1 -1 -1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_right"/>
 -                      <geom pos="0.0141637 -0.0211727 0.0597067" class="collision" quat="1 -1 -1 -1" type="mesh"
 +                      <geom pos="0.0141637 -0.0211727 0.0597067" class="finger_collision" quat="1 -1 -1 -1" type="mesh"
                          mesh="vx300s_8_custom_finger_right"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01  0.0192 0.015 0.015  0.0852 0.0228" class="primitive_collision"/>
-+                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035  -0.0192 0.015 0.02  0.0852 0.0228" class="primitive_collision"/>
-                       <geom name="right/right_g0" pos="0.013  0.0892 0.0268" class="sphere_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="-0.01 0.0192 0.015 0.015 0.0852 0.0228"
++                        class="primitive_collision"/>
++                      <geom pos="0 0 0" type="capsule" size="0.005" fromto="0.035 -0.0192 0.015 0.02 0.0852 0.0228"
++                        class="primitive_collision"/>
+                       <geom name="right/right_g0" pos="0.013 0.0892 0.0268" class="sphere_collision"/>
                        <geom name="right/right_g1" pos="0.0222 0.0892 0.0268" class="sphere_collision"/>
                        <geom name="right/right_g2" pos="0.0182 0.0845 0.0266" class="sphere_collision"/>
-@@ -285,6 +307,5 @@
+@@ -293,6 +323,5 @@
      <joint joint1="right/left_finger" joint2="right/right_finger" polycoef="0 1 0 0 0"/>
    </equality>
  

--- a/aloha/mjx_filtered_cartesian_actuators.patch
+++ b/aloha/mjx_filtered_cartesian_actuators.patch
@@ -1,7 +1,7 @@
---- filtered_cartesian_actuators.xml	2024-05-01 08:51:26.000000000 -0700
-+++ mjx_filtered_cartesian_actuators.xml	2024-05-01 08:51:26.000000000 -0700
+--- filtered_cartesian_actuators.xml
++++ mjx_filtered_cartesian_actuators.xml
 @@ -2,16 +2,13 @@
- <!-- The dynamical parameters in this file are not the result of system identification.
+   <!-- The dynamical parameters in this file are not the result of system identification.
  They were chosen for MJPC efficiency. The resulting qfrc is still limited by every joint's actuator_frcrange,
  as specified in the main model. -->
 -  <option integrator="implicitfast"/>

--- a/aloha/mjx_scene.patch
+++ b/aloha/mjx_scene.patch
@@ -1,21 +1,22 @@
---- scene.xml	2024-07-24 11:38:17.000000000 -0700
-+++ mjx_scene.xml	2024-09-25 10:13:59.000000000 -0700
-@@ -1,7 +1,13 @@
+--- scene.xml
++++ mjx_scene.xml
+@@ -1,8 +1,14 @@
  <mujoco model="aloha_scene">
    <compiler meshdir="assets" texturedir="assets"/>
  
 -  <include file="aloha.xml"/>
 +  <include file="mjx_aloha.xml"/>
-+
+ 
 +  <custom>
 +    <numeric data="12" name="max_contact_points"/>
 +  </custom>
 +
 +  <option iterations="8" ls_iterations="8" timestep="0.005"/>
- 
++
    <statistic center="0 -0.1 0.2" extent="0.6" meansize="0.05"/>
  
-@@ -40,17 +46,17 @@
+   <visual>
+@@ -40,17 +46,18 @@
  
    <default>
      <default class="frame">
@@ -32,7 +33,8 @@
      <geom mesh="tabletop" material="table" class="visual" pos="0 0 -0.75" quat="1 0 0 1"/>
      <geom mesh="tablelegs" material="table" class="visual" pos="0 0 -0.75" quat="1 0 0 1"/>
 -    <geom name="table" pos="0 0 -0.1009" size="0.61 0.37 0.1" type="box" class="collision"/>
-+    <geom name="table" pos="0 0 0.0008" size="0.61 0.37 0.1" type="plane" class="collision" contype="1" conaffinity="1"/>
++    <geom name="table" pos="0 0 0.0008" size="0.61 0.37 0.1" type="plane" class="collision" contype="1"
++      conaffinity="1"/>
      <camera name="overhead_cam" focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"
-             pos="0 -0.303794 1.02524" mode="fixed" quat="0.976332 0.216277 0 0"/>
+       pos="0 -0.303794 1.02524" mode="fixed" quat="0.976332 0.216277 0 0"/>
      <camera name="worms_eye_cam" focal="1.93e-3 1.93e-3" resolution="1280 720" sensorsize="3896e-6 2140e-6"


### PR DESCRIPTION
The XML reformat in #278 invalidated the three patches in `aloha/` that derive the MJX variants from the base XMLs. Regenerated each by applying the old patch to the pre-reformat base, formatting the result with `format_xml.py`, then re-diffing against the new (reformatted) base.

**Parity check:** compiled `mjx_scene.xml` from old (pre-#278) and new (this PR) versions to MJB binary and byte-compared — both produce an identical 55,564,578-byte file (SHA-256 prefix `6a193bfac547d412`). The patched MuJoCo model is semantically unchanged.