### PR TITLE
Add an Action for MuJoCo Live PR previews.

### DIFF
--- a/.github/workflows/live-pr-preview.yml
+++ b/.github/workflows/live-pr-preview.yml
@@ -1,0 +1,55 @@
+name: MuJoCo Live
+
+on:
+  pull_request_target:
+    paths:
+      - '**/*.xml'
+
+jobs:
+  generate-previews:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Collect list of XML files
+        id: changed-xml-files
+        uses: step-security/changed-files@v47
+        with:
+          files: '**/*.xml'
+
+      - name: Publish MuJoCo Live links
+        if: steps.changed-xml-files.outputs.any_changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Construct a Markdown document and publish it to GitHub Checks
+          MD_TEXT=""
+
+          for file in ${{ steps.changed-xml-files.outputs.all_changed_files }}; do
+            URL="https://live.mujoco.org/?model=github:${{ github.repository }}/pull/${{ github.event.pull_request.number }}/head/$file"
+            MD_TEXT="$MD_TEXT- [\`$file\`]($URL)"$'\n'
+          done
+
+          # 2. Safely construct the JSON payload using jq to prevent escaping issues
+          jq -n \
+            --arg head_sha "${{ github.event.pull_request.head.sha }}" \
+            --arg text "$MD_TEXT" \
+            '{
+              name: "🚀 MuJoCo Live Previews",
+              head_sha: $head_sha,
+              status: "completed",
+              conclusion: "success",
+              output: {
+                title: "MuJoCo Live",
+                summary: "Preview links for modified XML files in this Pull Request.",
+                text: $text
+              }
+            }' > payload.json
+
+          # 3. Send to GitHub Checks API
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/check-runs \
+            --input payload.json


### PR DESCRIPTION
# Description

Add a new GitHub Action to generate MuJoCo Live preview links for pull requests.

# Checklist

N/A

The new Action was tested on my own fork.
