### PR TITLE
Restrict GITHUB_TOKEN permissions in build and pre-commit workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the two open code scanning alerts (`actions/missing-workflow-permissions`) by adding an explicit least-privilege `permissions: contents: read` block to `build.yml` and `pre-commit.yml`. Both jobs only check out the repo and run tests, so read access is sufficient.