### PR TITLE
Clean up scene <statistic> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this repository will be documented here.
 
+## [2026-07-04]
+
+- Cleaned up manual `<statistic>` camera overrides across scene XMLs to improve visualizer default framings. Removed arbitrary `center` attributes, only keeping `extent` where finite floor surfaces or heightfields require custom framing bounds.
+
 ## [2026-05-19]
 
 - Streamlined the contributor workflow behind a top-level `Makefile`: `make install` for one-time setup, `make check` for lint/format/license/XML, `make test` for the simulation suite, `make all` for everything CI runs. Slimmed the PR template and rewrote the CONTRIBUTING dev-setup section to match. Removed the redundant `check_license.yml` workflow (its job is already covered by the pre-commit workflow).

--- a/agilex_piper/scene.xml
+++ b/agilex_piper/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="piper_scene">
   <include file="piper.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.4"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/agility_cassie/scene.xml
+++ b/agility_cassie/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="cassie scene">
   <include file="cassie.xml"/>
 
-  <statistic center="0 0 0.55" extent="1.1"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/aloha/scene.xml
+++ b/aloha/scene.xml
@@ -3,7 +3,7 @@
 
   <include file="aloha.xml"/>
 
-  <statistic center="0 -0.1 0.2" extent="0.6" meansize="0.05"/>
+  <statistic meansize="0.05" extent="0.8"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/anybotics_anymal_b/scene.xml
+++ b/anybotics_anymal_b/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="anymal_b scene">
   <include file="anymal_b.xml"/>
 
-  <statistic center="0 0 0.3" extent="1.2"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/anybotics_anymal_c/scene.xml
+++ b/anybotics_anymal_c/scene.xml
@@ -7,8 +7,6 @@
     <global azimuth="120" elevation="-20"/>
   </visual>
 
-  <statistic center="0 0 .3" extent="1.2"/>
-
   <asset>
     <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
     <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"

--- a/anybotics_anymal_c/scene_mjx.xml
+++ b/anybotics_anymal_c/scene_mjx.xml
@@ -7,8 +7,6 @@
     <global azimuth="120" elevation="-20"/>
   </visual>
 
-  <statistic center="0 0 .3" extent="1.2"/>
-
   <asset>
     <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
     <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"

--- a/apptronik_apollo/scene.xml
+++ b/apptronik_apollo/scene.xml
@@ -3,8 +3,6 @@
 
   <option timestep="0.005" iterations="4" ls_iterations="10" integrator="implicitfast"/>
 
-  <statistic center="1 -0.8 1.1" extent=".35"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0.9 0.9 0.9"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/arx_l5/scene.xml
+++ b/arx_l5/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="ARX L5 scene">
   <include file="arx_l5.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/berkeley_humanoid/scene.xml
+++ b/berkeley_humanoid/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="berkeley humanoid scene">
   <include file="berkeley_humanoid.xml"/>
 
-  <statistic center="0 0 0.43" extent=".85" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/bitcraze_crazyflie_2/scene.xml
+++ b/bitcraze_crazyflie_2/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="CF2 scene">
   <include file="cf2.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.2" meansize=".05"/>
+  <statistic meansize=".05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/booster_t1/scene.xml
+++ b/booster_t1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="t1 scene">
   <include file="t1.xml"/>
 
-  <statistic center="0.35 0.1 0.7" extent="0.85"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/boston_dynamics_spot/scene.xml
+++ b/boston_dynamics_spot/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="spot scene">
   <include file="spot.xml"/>
 
-  <statistic center="0.15 0.1 0.38" extent=".8" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/boston_dynamics_spot/scene_arm.xml
+++ b/boston_dynamics_spot/scene_arm.xml
@@ -1,7 +1,7 @@
 <mujoco model="spot with arm scene">
   <include file="spot_arm.xml"/>
 
-  <statistic center="0.15 0.1 0.38" extent=".8" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/dynamixel_2r/scene.xml
+++ b/dynamixel_2r/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="scene">
   <include file="dynamixel_2r.xml"/>
 
-  <statistic center="0 0 0.3" extent=".6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/flexiv_rizon4/scene.xml
+++ b/flexiv_rizon4/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="flexiv scene">
   <include file="flexiv_rizon4.xml"/>
 
-  <statistic center="0.2 0 0.5" extent="1.2"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/flexiv_rizon4s/scene.xml
+++ b/flexiv_rizon4s/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="flexiv scene">
   <include file="flexiv_rizon4s.xml"/>
 
-  <statistic center="0.0 0 0.75" extent="1.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/fourier_n1/scene.xml
+++ b/fourier_n1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="N1 scene">
   <include file="n1.xml"/>
 
-  <statistic center="0 0 0.65" extent="1.1"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/franka_emika_panda/mjx_scene.xml
+++ b/franka_emika_panda/mjx_scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="panda scene">
   <include file="mjx_panda.xml"/>
 
-  <statistic center="0.3 0 0.4" extent="1"/>
-
   <option timestep="0.005" iterations="5" ls_iterations="8" integrator="implicitfast">
     <flag eulerdamp="disable"/>
   </option>

--- a/franka_emika_panda/scene.xml
+++ b/franka_emika_panda/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="panda scene">
   <include file="panda.xml"/>
 
-  <statistic center="0.3 0 0.4" extent="1"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/franka_fr3/scene.xml
+++ b/franka_fr3/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="fr3 scene">
   <include file="fr3.xml"/>
 
-  <statistic center="0.2 0 0.4" extent=".8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/franka_fr3_v2/scene.xml
+++ b/franka_fr3_v2/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="fr3v2 scene">
   <include file="fr3v2.xml"/>
 
-  <statistic center="0.2 0 0.4" extent=".8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/google_barkour_v0/scene.xml
+++ b/google_barkour_v0/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="barkour v0 scene">
   <include file="barkour_v0.xml"/>
 
-  <statistic center="0 0 0.3" extent="1.2"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/google_barkour_v0/scene_mjx.xml
+++ b/google_barkour_v0/scene_mjx.xml
@@ -1,8 +1,6 @@
 <mujoco model="barkour v0 scene">
   <include file="barkour_v0_mjx.xml"/>
 
-  <statistic center="0 0 0.3" extent="1.2"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/google_barkour_vb/scene.xml
+++ b/google_barkour_vb/scene.xml
@@ -3,8 +3,6 @@
 
   <include file="barkour_vb.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/google_barkour_vb/scene_hfield_mjx.xml
+++ b/google_barkour_vb/scene_hfield_mjx.xml
@@ -1,7 +1,7 @@
 <mujoco model="barkour vB scene">
   <include file="barkour_vb_mjx.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
+  <statistic extent="0.8"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/google_barkour_vb/scene_mjx.xml
+++ b/google_barkour_vb/scene_mjx.xml
@@ -1,8 +1,6 @@
 <mujoco model="barkour vB scene">
   <include file="barkour_vb_mjx.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/google_robot/scene.xml
+++ b/google_robot/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="robot scene">
   <include file="robot.xml"/>
 
-  <statistic center="0 0 0.8" extent="2"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/hello_robot_stretch/scene.xml
+++ b/hello_robot_stretch/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="stretch scene">
   <include file="stretch.xml"/>
 
-  <statistic center="0 0 .75" extent="1.2" meansize="0.05"/>
+  <statistic meansize="0.05" extent="1.2"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/hello_robot_stretch_3/scene.xml
+++ b/hello_robot_stretch_3/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="stretch scene">
   <include file="stretch.xml"/>
 
-  <statistic center="0 0 .75" extent="1.2" meansize="0.05"/>
+  <statistic meansize="0.05" extent="1.2"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/i2rt_yam/scene.xml
+++ b/i2rt_yam/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="yam scene">
   <include file="yam.xml"/>
 
-  <statistic center="0.2 -0.1 0.3" extent="0.45"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/iit_softfoot/scene.xml
+++ b/iit_softfoot/scene.xml
@@ -1,5 +1,5 @@
 <mujoco model="softfoot scene">
-  <statistic center="0 0 0.1" extent=".3"/>
+  <statistic extent=".3"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/kinova_gen3/scene.xml
+++ b/kinova_gen3/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="gen3 scene">
   <include file="gen3.xml"/>
 
-  <statistic center="0.3 0 0.45" extent="0.8" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>

--- a/kuka_iiwa_14/scene.xml
+++ b/kuka_iiwa_14/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="iiwa14 scene">
   <include file="iiwa14.xml"/>
 
-  <statistic center="0.2 0 0.2" extent="1.0"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/leap_hand/scene_left.xml
+++ b/leap_hand/scene_left.xml
@@ -1,8 +1,6 @@
 <mujoco model="left leap hand scene">
   <include file="left_hand.xml"/>
 
-  <statistic center="-0.07 0.1 0.12" extent=".3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/leap_hand/scene_right.xml
+++ b/leap_hand/scene_right.xml
@@ -1,8 +1,6 @@
 <mujoco model="right leap hand scene">
   <include file="right_hand.xml"/>
 
-  <statistic center="0 0 0.1" extent=".3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/low_cost_robot_arm/scene.xml
+++ b/low_cost_robot_arm/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="low_cost_robot scene">
   <include file="low_cost_robot_arm.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/ms_human_700/scene.xml
+++ b/ms_human_700/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="MS_Human_700_Primary_Model scene">
   <include file="MS-Human-700.xml"/>
 
-  <statistic center="0 0 1.0" extent="1.2"/>
-
   <visual>
     <headlight ambient="0.4 0.4 0.4" diffuse="0.8 0.8 0.8" specular="0.1 0.1 0.1"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/ms_human_700/scene_locomotion.xml
+++ b/ms_human_700/scene_locomotion.xml
@@ -1,8 +1,6 @@
 <mujoco model="MS_Human_700_Locomotion_Model scene">
   <include file="MS-Human-700-Locomotion.xml"/>
 
-  <statistic center="0 0 1.0" extent="1.2"/>
-
   <visual>
     <headlight ambient="0.4 0.4 0.4" diffuse="0.8 0.8 0.8" specular="0.1 0.1 0.1"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/ms_human_700/scene_manipulation.xml
+++ b/ms_human_700/scene_manipulation.xml
@@ -1,8 +1,6 @@
 <mujoco model="MS_Human_700_Manipulation_Model scene">
   <include file="MS-Human-700-Manipulation.xml"/>
 
-  <statistic center="0.45 0 1.0" extent="1.2"/>
-
   <visual>
     <headlight ambient="0.4 0.4 0.4" diffuse="0.8 0.8 0.8" specular="0.1 0.1 0.1"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/pal_talos/scene_motor.xml
+++ b/pal_talos/scene_motor.xml
@@ -1,8 +1,6 @@
 <mujoco model="talos motor scene">
   <include file="talos_motor.xml"/>
 
-  <statistic center="0 0 .9" extent="1.5"/>
-
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="160" elevation="-10"/>

--- a/pal_talos/scene_position.xml
+++ b/pal_talos/scene_position.xml
@@ -1,8 +1,6 @@
 <mujoco model="talos position scene">
   <include file="talos_position.xml"/>
 
-  <statistic center="0 0 .9" extent="1.5"/>
-
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="160" elevation="-10"/>

--- a/pndbotics_adam_lite/scene.xml
+++ b/pndbotics_adam_lite/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="adam_lite scene">
   <include file="adam_lite.xml"/>
 
-  <statistic center="0 0 1" extent="1.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/rethink_robotics_sawyer/scene.xml
+++ b/rethink_robotics_sawyer/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="sawyer scene">
   <include file="sawyer.xml"/>
 
-  <statistic center="0.3 0 0.4" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/robot_soccer_kit/scene.xml
+++ b/robot_soccer_kit/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="scene">
   <include file="robot_soccer_kit.xml"/>
 
-  <statistic center="0 0 0.05" extent="0.25"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/robotiq_2f85/scene.xml
+++ b/robotiq_2f85/scene.xml
@@ -4,8 +4,6 @@
   <!-- Add some fluid viscosity to prevent the hanging box from jiggling forever -->
   <option viscosity="0.1"/>
 
-  <statistic center="0 0 0.05" extent="0.3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/robotiq_2f85_v4/scene.xml
+++ b/robotiq_2f85_v4/scene.xml
@@ -4,8 +4,6 @@
   <!-- Add some fluid viscosity to prevent the hanging box from jiggling forever -->
   <option viscosity="0.1"/>
 
-  <statistic center="0 0 0.05" extent="0.3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/robotis_op3/scene.xml
+++ b/robotis_op3/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="op3 scene">
   <include file="op3.xml"/>
 
-  <statistic center="0 0 0.2" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/shadow_dexee/scene.xml
+++ b/shadow_dexee/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="shadow dex-ee hand scene">
   <include file="shadow_dexee.xml"/>
 
-  <statistic extent=".5" center="0 0 0.1"/>
+  <statistic extent=".5"/>
 
   <visual>
     <headlight ambient=".3 .3 .3" diffuse=".6 .6 .6" specular="0 0 0"/>

--- a/shadow_hand/scene_left.xml
+++ b/shadow_hand/scene_left.xml
@@ -1,7 +1,7 @@
 <mujoco model="left_shadow_hand scene">
   <include file="left_hand.xml"/>
 
-  <statistic extent="0.3" center="0.3 0 0"/>
+  <statistic extent="0.3"/>
 
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/shadow_hand/scene_right.xml
+++ b/shadow_hand/scene_right.xml
@@ -1,7 +1,7 @@
 <mujoco model="right_shadow_hand scene">
   <include file="right_hand.xml"/>
 
-  <statistic extent="0.3" center="0.3 0 0"/>
+  <statistic extent="0.3"/>
 
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/sharpa_wave/scene_left.xml
+++ b/sharpa_wave/scene_left.xml
@@ -1,8 +1,6 @@
 <mujoco model="left_sharpa_wave scene">
   <include file="left_hand.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/sharpa_wave/scene_right.xml
+++ b/sharpa_wave/scene_right.xml
@@ -1,8 +1,6 @@
 <mujoco model="right_sharpa_wave scene">
   <include file="right_hand.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.3"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/skydio_x2/scene.xml
+++ b/skydio_x2/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="Skydio X2 scene">
   <include file="x2.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.6" meansize=".05"/>
+  <statistic meansize=".05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/stanford_tidybot/scene.xml
+++ b/stanford_tidybot/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="tidybot scene">
   <include file="tidybot.xml"/>
 
-  <statistic center="0 0 0.525" extent="1.1" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>

--- a/stanford_tidybot/scene_base.xml
+++ b/stanford_tidybot/scene_base.xml
@@ -1,7 +1,7 @@
 <mujoco model="base scene">
   <include file="base.xml"/>
 
-  <statistic center="0 0 0.2" extent="0.8" meansize="0.05"/>
+  <statistic meansize="0.05"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>

--- a/tetheria_aero_hand_open/scene_right.xml
+++ b/tetheria_aero_hand_open/scene_right.xml
@@ -1,7 +1,7 @@
 <mujoco model="tetheria_aero_hand_open_right_scene">
   <include file="right_hand.xml"/>
 
-  <statistic center="0.15 0 0" extent="0.4" meansize="0.01"/>
+  <statistic meansize="0.01"/>
 
   <visual>
     <headlight diffuse=".8 .8 .8" ambient=".2 .2 .2" specular="1 1 1"/>

--- a/toddlerbot_2xc/scene.xml
+++ b/toddlerbot_2xc/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xc_scene">
   <include file="toddlerbot_2xc.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/toddlerbot_2xc/scene_mjx.xml
+++ b/toddlerbot_2xc/scene_mjx.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xc_mjx_scene">
   <include file="toddlerbot_2xc_mjx.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/toddlerbot_2xc/scene_pos.xml
+++ b/toddlerbot_2xc/scene_pos.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xc_pos_scene">
   <include file="toddlerbot_2xc_pos.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/toddlerbot_2xm/scene.xml
+++ b/toddlerbot_2xm/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xm_scene">
   <include file="toddlerbot_2xm.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/toddlerbot_2xm/scene_mjx.xml
+++ b/toddlerbot_2xm/scene_mjx.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xm_mjx_scene">
   <include file="toddlerbot_2xm_mjx.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/toddlerbot_2xm/scene_pos.xml
+++ b/toddlerbot_2xm/scene_pos.xml
@@ -1,8 +1,6 @@
 <mujoco model="toddlerbot_2xm_pos_scene">
   <include file="toddlerbot_2xm_pos.xml"/>
 
-  <statistic center="0 0 0.25" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/trossen_vx300s/scene.xml
+++ b/trossen_vx300s/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="vx300s scene">
   <include file="vx300s.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/trossen_wx250s/scene.xml
+++ b/trossen_wx250s/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="wx250s scene">
   <include file="wx250s.xml"/>
 
-  <statistic center="0 0 0.12" extent="0.4"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/trossen_wxai/scene.xml
+++ b/trossen_wxai/scene.xml
@@ -1,7 +1,7 @@
 <mujoco model="wxai_scene">
   <compiler angle="radian"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
+  <statistic extent="0.8"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>

--- a/trs_so_arm100/scene.xml
+++ b/trs_so_arm100/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="so_arm100 scene">
   <include file="so_arm100.xml"/>
 
-  <statistic center="0.1 -0.01 0.05" extent="0.5"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/ufactory_lite6/scene.xml
+++ b/ufactory_lite6/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="lite6 scene">
   <include file="lite6.xml"/>
 
-  <statistic center="0 0 0.3" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/ufactory_xarm7/scene.xml
+++ b/ufactory_xarm7/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="xarm7 scene">
   <include file="xarm7.xml"/>
 
-  <statistic center="0.2 0 0.4" extent=".65"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/umi_gripper/scene.xml
+++ b/umi_gripper/scene.xml
@@ -2,7 +2,7 @@
 
   <include file="umi_gripper.xml"/>
 
-  <statistic center="0.2 0 0.2" extent="1.0"/>
+  <statistic extent="1.0"/>
 
   <visual>
     <headlight diffuse="0.3 0.3 0.3" ambient="0.2 0.2 0.2" specular="0 0 0"/>

--- a/unitree_a1/scene.xml
+++ b/unitree_a1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="a1 scene">
   <include file="a1.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_g1/scene.xml
+++ b/unitree_g1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="g1_29dof_rev_1_0 scene">
   <include file="g1.xml"/>
 
-  <statistic center="1 -0.8 1.1" extent=".35"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0.9 0.9 0.9"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_g1/scene_mjx.xml
+++ b/unitree_g1/scene_mjx.xml
@@ -1,7 +1,7 @@
 <mujoco model="g1 mjx flat terrain scene">
   <include file="g1_mjx.xml"/>
 
-  <statistic center="0 0 0.7" extent="1.2" meansize="0.02"/>
+  <statistic meansize="0.02"/>
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0.9 0.9 0.9"/>

--- a/unitree_g1/scene_with_hands.xml
+++ b/unitree_g1/scene_with_hands.xml
@@ -1,8 +1,6 @@
 <mujoco model="g1_29dof_with_hand_rev_1_0 scene">
   <include file="g1_with_hands.xml"/>
 
-  <statistic center="1 -0.8 1.1" extent=".35"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0.9 0.9 0.9"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_go1/scene.xml
+++ b/unitree_go1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="go1 scene">
   <include file="go1.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_go2/scene.xml
+++ b/unitree_go2/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="go2 scene">
   <include file="go2.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_go2/scene_mjx.xml
+++ b/unitree_go2/scene_mjx.xml
@@ -1,8 +1,6 @@
 <mujoco model="go2 scene">
   <include file="go2_mjx.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_h1/scene.xml
+++ b/unitree_h1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="h1 scene">
   <include file="h1.xml"/>
 
-  <statistic center="0 0 1" extent="1.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/unitree_z1/scene.xml
+++ b/unitree_z1/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="z1 scene">
   <include file="z1.xml"/>
 
-  <statistic center="0 0 0.1" extent="0.6"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/universal_robots_ur10e/scene.xml
+++ b/universal_robots_ur10e/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="ur10e scene">
   <include file="ur10e.xml"/>
 
-  <statistic center="0.4 0 0.4" extent="1"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/universal_robots_ur5e/scene.xml
+++ b/universal_robots_ur5e/scene.xml
@@ -1,8 +1,6 @@
 <mujoco model="ur5e scene">
   <include file="ur5e.xml"/>
 
-  <statistic center="0.3 0 0.4" extent="0.8"/>
-
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>

--- a/wonik_allegro/scene_left.xml
+++ b/wonik_allegro/scene_left.xml
@@ -1,8 +1,6 @@
 <mujoco model="left_allegro_hand scene">
   <include file="left_hand.xml"/>
 
-  <statistic center="0 0 0" extent="0.3"/>
-
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>
     <quality shadowsize="8192"/>

--- a/wonik_allegro/scene_right.xml
+++ b/wonik_allegro/scene_right.xml
@@ -1,8 +1,6 @@
 <mujoco model="right_allegro_hand scene">
   <include file="right_hand.xml"/>
 
-  <statistic center="0 0 0" extent="0.3"/>
-
   <visual>
     <rgba haze="0.15 0.25 0.35 1"/>
     <quality shadowsize="8192"/>


### PR DESCRIPTION
Removes arbitrary `center` attributes from scene `<statistic>` tags, keeping `extent` only for finite floors/heightfields and preserving `meansize`. Improves default visualizer framings.

Patch authored by Yuval Tassa.