### PR TITLE
Fix UnicodeDecodeError in the top-level tooling on non-UTF-8 locales

### DIFF
--- a/format_xml.py
+++ b/format_xml.py
@@ -170,14 +170,14 @@ def main() -> int:
 
   failed: list[pathlib.Path] = []
   for p in args.paths:
-    text = p.read_text()
+    text = p.read_text(encoding='utf-8')
     formatted = format_xml(text)
     if args.check:
       if text != formatted:
         failed.append(p)
     elif args.write:
       if text != formatted:
-        p.write_text(formatted)
+        p.write_text(formatted, encoding='utf-8')
     else:
       sys.stdout.write(formatted)
 

--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -76,7 +76,13 @@ def display_name(robot):
   maker = robot.split('/')[0]
   readme = pathlib.Path(f'{maker}/README.md')
   if readme.exists():
-    title = readme.read_text().splitlines()[0].strip().lstrip('#').strip()
+    title = (
+      readme.read_text(encoding='utf-8')
+      .splitlines()[0]
+      .strip()
+      .lstrip('#')
+      .strip()
+    )
     title = _README_TITLE_SUFFIX.sub('', title).rstrip()
     if title:
       return title
@@ -381,7 +387,7 @@ MODELS_END = '<!-- END MODELS -->'
 
 def detect_license(license_path):
   """Identify the SPDX license name from the LICENSE file contents."""
-  text = pathlib.Path(license_path).read_text()
+  text = pathlib.Path(license_path).read_text(encoding='utf-8')
   lower = text.lower()
   if 'apache license' in lower and 'version 2' in lower:
     return 'Apache-2.0'
@@ -440,7 +446,7 @@ def write_gallery_to_readme(rendered, dofs, readme_path='README.md'):
     sections.append(table)
 
   body = '\n\n'.join(sections)
-  readme = pathlib.Path(readme_path).read_text()
+  readme = pathlib.Path(readme_path).read_text(encoding='utf-8')
   pattern = re.compile(
     re.escape(MODELS_BEGIN) + r'.*?' + re.escape(MODELS_END), re.DOTALL
   )
@@ -449,7 +455,7 @@ def write_gallery_to_readme(rendered, dofs, readme_path='README.md'):
       f'models markers not found in {readme_path}; expected\n  {MODELS_BEGIN}\n  {MODELS_END}'
     )
   new = pattern.sub(f'{MODELS_BEGIN}\n\n{body}\n\n{MODELS_END}', readme)
-  pathlib.Path(readme_path).write_text(new)
+  pathlib.Path(readme_path).write_text(new, encoding='utf-8')
 
 
 def main(argv):

--- a/regenerate_license.py
+++ b/regenerate_license.py
@@ -45,12 +45,12 @@ def get_base_license(root: pathlib.Path) -> str:
   """
   opensource_license = root / 'opensource' / 'LICENSE'
   if opensource_license.exists():
-    return opensource_license.read_text()
+    return opensource_license.read_text(encoding='utf-8')
 
   # Fall back to extracting from the existing concatenated LICENSE.
   existing = root / 'LICENSE'
   if existing.exists():
-    sections = existing.read_text().split(HLINE + '\n')
+    sections = existing.read_text(encoding='utf-8').split(HLINE + '\n')
     if sections:
       return sections[-1]
 
@@ -84,7 +84,7 @@ def generate_license(root: pathlib.Path) -> str:
     out += HLINE
     out += f"License for contents in the directory '{lf.parent.name}/'\n"
     out += HLINE + '\n'
-    out += lf.read_text() + '\n\n'
+    out += lf.read_text(encoding='utf-8') + '\n\n'
 
   out += HLINE
   out += 'The following license applies to all other contents\n'
@@ -115,7 +115,7 @@ def main():
       print('FAIL: LICENSE file does not exist.', file=sys.stderr)
       sys.exit(1)
 
-    current = license_path.read_text()
+    current = license_path.read_text(encoding='utf-8')
     if current != generated:
       print(
         'FAIL: LICENSE file is out of date. '
@@ -127,7 +127,7 @@ def main():
     print('OK: LICENSE file is up to date.')
     return
 
-  license_path.write_text(generated)
+  license_path.write_text(generated, encoding='utf-8')
   print(f'LICENSE file regenerated at {license_path}')
 
 

--- a/test/model_dir_test.py
+++ b/test/model_dir_test.py
@@ -84,7 +84,9 @@ class ContributorsTest(absltest.TestCase):
   """Checks CONTRIBUTORS.md sections are sorted alphabetically by first name."""
 
   def test_sorted(self) -> None:
-    contributors = (_ROOT_DIR / 'CONTRIBUTORS.md').read_text().splitlines()
+    contributors = (
+      (_ROOT_DIR / 'CONTRIBUTORS.md').read_text(encoding='utf-8').splitlines()
+    )
 
     # Each section is a contiguous block of lines starting with "- ".
     section_start = None


### PR DESCRIPTION

## Summary

`make gallery` and the `regenerate-license` pre-commit hook both crash on any
system whose preferred encoding is not UTF-8 (e.g. Windows, where it is cp1252).

The tooling calls `pathlib.Path.read_text()` / `.write_text()` with no
`encoding=`, so Python falls back to `locale.getpreferredencoding(False)`. Four
`LICENSE` files contain UTF-8 curly quotes (U+201C/U+201D — `the "Software"`,
`"AS IS"`), whose bytes are not decodable as cp1252:

- `bitcraze_crazyflie_2/LICENSE`
- `iit_softfoot/LICENSE`
- `kinova_gen3/LICENSE`
- `leap_hand/LICENSE`

All four are in `MODEL_MAP`, so `generate_gallery.detect_license()` always
reaches them.

## Reproduction

On Windows (`locale.getpreferredencoding(False) == 'cp1252'`), at `main`:

```
$ python generate_gallery.py
  File "generate_gallery.py", line 384, in detect_license
    text = pathlib.Path(license_path).read_text()
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 813:
character maps to <undefined>

$ python regenerate_license.py --check
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 23543:
character maps to <undefined>
```

`make gallery` dies before rendering a single thumbnail. The
`regenerate-license` hook fails for the same reason, so `pre-commit` cannot be
run at all.

CI does not catch this because `build.yml` / `pre-commit.yml` run on
`ubuntu-latest`, where the preferred encoding is already UTF-8.

## Fix

Pass `encoding='utf-8'` explicitly at every text read/write in the four
top-level tools. Files are UTF-8 on disk; this just stops Python guessing from
the ambient locale.

- `generate_gallery.py` — `display_name`, `detect_license`,
  `write_gallery_to_readme` (read + write)
- `regenerate_license.py` — `get_base_license`, `generate_license`, `main`
  (read + write)
- `format_xml.py` — `main` (read + write)
- `test/model_dir_test.py` — `ContributorsTest.test_sorted`

`detect_license` and `regenerate_license` are the two that crash today; the
others are the same defect and are fixed for consistency rather than because
they currently fail (`format_xml` writes XML, so a locale-encoded write there
would silently corrupt a non-ASCII model file).

## Scope

Only the top-level tooling. The two model-authoring scripts
(`sharpa_wave/make_right.py`, `trossen_wxai/create_biarm.py`) have the same
pattern but are one-off conversion scripts, not part of `make` or `pre-commit` —
happy to include them if you'd rather have the sweep be exhaustive.

No behaviour change on a UTF-8 locale: the bytes read are identical, so the
generated gallery, LICENSE and formatted XML are unchanged.

## Test plan

Run on Windows / cp1252, at this branch:

- [x] `python regenerate_license.py --check` → `OK: LICENSE file is up to date.`
      (was: `UnicodeDecodeError`)
- [x] `detect_license()` reads all 67 `LICENSE` files; the 4 above classify as
      MIT / BSD-3-Clause / BSD-3-Clause / MIT (was: crash on the 1st)
- [x] `pytest test/` → 364 passed, 1 skipped
- [x] `ruff check` and `ruff format --check` (pinned v0.8.4) clean on all four
      files; `main` is also clean, so this adds no new lint
