### PR TITLE
Fix compute_gains.py: MuJoCo 3.10+ API and mass-matrix DOF indexing

### DIFF
--- a/flexiv_rizon4/CHANGELOG.md
+++ b/flexiv_rizon4/CHANGELOG.md
@@ -3,10 +3,7 @@
 All notable changes to this model will be documented in this file.
 
 ## [2026-08-21]
-- Fixed `compute_gains.py` to run with MuJoCo 3.10+ (the `mj_fullM` signature
-  changed) and to index the mass-matrix diagonal by DOF address instead of
-  joint id, which previously read the wrong entry whenever a free or
-  multi-DOF joint precedes a joint in the model.
+- Fixed `compute_gains.py` for MuJoCo 3.10+ and its mass matrix indexing.
 
 ## [2026-02-06]
 - Initial release.

--- a/flexiv_rizon4/CHANGELOG.md
+++ b/flexiv_rizon4/CHANGELOG.md
@@ -2,5 +2,11 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2026-08-21]
+- Fixed `compute_gains.py` to run with MuJoCo 3.10+ (the `mj_fullM` signature
+  changed) and to index the mass-matrix diagonal by DOF address instead of
+  joint id, which previously read the wrong entry whenever a free or
+  multi-DOF joint precedes a joint in the model.
+
 ## [2026-02-06]
 - Initial release.

--- a/flexiv_rizon4/compute_gains.py
+++ b/flexiv_rizon4/compute_gains.py
@@ -1,5 +1,5 @@
 # /// script
-# dependencies = ["mujoco", "numpy"]
+# dependencies = ["mujoco>=3.10", "numpy"]
 # ///
 """Compute PD gains for the Flexiv Rizon4 from effective inertia.
 
@@ -38,14 +38,9 @@ def compute_gains(model_path: Path) -> None:
   data = mujoco.MjData(model)
   mujoco.mj_forward(model, data)
 
-  # Dense mass matrix at qpos0. The mj_fullM signature changed in MuJoCo 3.10
-  # (from (model, dst, data.qM) to (model, data, dst)), so dispatch on the API
-  # actually available instead of pinning a specific version.
+  # Dense mass matrix at qpos0.
   M = np.zeros((model.nv, model.nv))
-  try:
-    mujoco.mj_fullM(model, M, data.qM)
-  except (AttributeError, TypeError):
-    mujoco.mj_fullM(model, data, M)
+  mujoco.mj_fullM(model, data, M)
   effective_inertia = np.diag(M)
 
   delta_theta = math.radians(SATURATION_ANGLE_DEG)
@@ -56,9 +51,7 @@ def compute_gains(model_path: Path) -> None:
     joint_id = model.actuator_trnid[i, 0]
     name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
     frc_max = model.jnt_actfrcrange[joint_id, 1]
-    # The mass-matrix diagonal is indexed by DOF address (jnt_dofadr), not by
-    # joint id: the two diverge whenever a free joint, ball joint or any
-    # multi-DOF joint precedes this one in the model.
+    # The mass matrix diagonal is indexed by DOF address, not joint id.
     m_ii = effective_inertia[model.jnt_dofadr[joint_id]]
     # Use forcerange as class key.
     key = frc_max

--- a/flexiv_rizon4/compute_gains.py
+++ b/flexiv_rizon4/compute_gains.py
@@ -38,9 +38,14 @@ def compute_gains(model_path: Path) -> None:
   data = mujoco.MjData(model)
   mujoco.mj_forward(model, data)
 
-  # Dense mass matrix at qpos0.
+  # Dense mass matrix at qpos0. The mj_fullM signature changed in MuJoCo 3.10
+  # (from (model, dst, data.qM) to (model, data, dst)), so dispatch on the API
+  # actually available instead of pinning a specific version.
   M = np.zeros((model.nv, model.nv))
-  mujoco.mj_fullM(model, M, data.qM)
+  try:
+    mujoco.mj_fullM(model, M, data.qM)
+  except (AttributeError, TypeError):
+    mujoco.mj_fullM(model, data, M)
   effective_inertia = np.diag(M)
 
   delta_theta = math.radians(SATURATION_ANGLE_DEG)
@@ -51,7 +56,10 @@ def compute_gains(model_path: Path) -> None:
     joint_id = model.actuator_trnid[i, 0]
     name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
     frc_max = model.jnt_actfrcrange[joint_id, 1]
-    m_ii = effective_inertia[joint_id]
+    # The mass-matrix diagonal is indexed by DOF address (jnt_dofadr), not by
+    # joint id: the two diverge whenever a free joint, ball joint or any
+    # multi-DOF joint precedes this one in the model.
+    m_ii = effective_inertia[model.jnt_dofadr[joint_id]]
     # Use forcerange as class key.
     key = frc_max
     if key not in classes:


### PR DESCRIPTION
## Description

`flexiv_rizon4/compute_gains.py` (documented in the README as the tool to reproduce/tune the arm's PD gains) is currently broken on MuJoCo 3.10+:

1. **Crash on modern MuJoCo.** `mj_fullM`'s Python signature changed in MuJoCo 3.10 from `mj_fullM(model, dst, data.qM)` to `mj_fullM(model, data, dst)`, and `data.qM` was removed in 3.11+. With the script's unpinned `mujoco` dependency, `uv run compute_gains.py` fails immediately with `AttributeError`/`TypeError`. The fix dispatches on the available API and runs on both MuJoCo 3.2.x and 3.10+.

2. **Wrong effective-inertia lookup.** The mass-matrix diagonal is indexed by joint id (`effective_inertia[joint_id]`), but the diagonal is laid out by DOF address. `jnt_dofadr[joint_id]` diverges from `joint_id` whenever a free joint, ball joint or any multi-DOF joint precedes a joint, so the script silently used the wrong `M_ii` for such models. Now it reads `effective_inertia[model.jnt_dofadr[joint_id]]`.

## Verification

- Reproduced the crash with the installed/latest MuJoCo (3.12.0) on the checked-in `flexiv_rizon4.xml`.
- Demonstrated the indexing bug with a probe model containing a free joint: the script read `M[1,1]=2.0` instead of the hinge joint's true `M[6,6]=0.004`.
- Confirmed the fixed script produces identical gains for the checked-in Rizon4 model across MuJoCo 3.2.0, 3.10.0, 3.11.0 and 3.12.0 (the Rizon4 arm has only 1-DOF joints, so the DOF-address change is a no-op there and only fixes the general case).

Fixes the README-referenced reproduction path for `compute_gains.py` on current MuJoCo.