### PR TITLE
Fix tidybot base_link inertia in base.xml

### DIFF
--- a/stanford_tidybot/CHANGELOG.md
+++ b/stanford_tidybot/CHANGELOG.md
@@ -3,9 +3,7 @@
 All notable changes to this model will be documented in this file.
 
 ## [2026-08-24]
-- Fix `base_link` mass and inertia in `base.xml`, matching the fix already applied to
-  `tidybot.xml` in #281 (fixes #231): drop the placeholder `diaginertia="0.001 0.001 0.001"`
-  and derive the base inertia from the body mesh geometry instead.
+- Fix `base_link` inertia in `base.xml`, matching the `tidybot.xml` fix in #281.
 
 ## [2024-09-09]
 - Initial release.

--- a/stanford_tidybot/CHANGELOG.md
+++ b/stanford_tidybot/CHANGELOG.md
@@ -2,5 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2026-08-24]
+- Fix `base_link` mass and inertia in `base.xml`, matching the fix already applied to
+  `tidybot.xml` in #281 (fixes #231): drop the placeholder `diaginertia="0.001 0.001 0.001"`
+  and derive the base inertia from the body mesh geometry instead.
+
 ## [2024-09-09]
 - Initial release.

--- a/stanford_tidybot/base.xml
+++ b/stanford_tidybot/base.xml
@@ -4,6 +4,7 @@
   <option integrator="implicitfast"/>
 
   <default>
+    <geom mass="0"/>
     <default class="visual">
       <geom type="mesh" contype="0" conaffinity="0" group="2"/>
     </default>
@@ -25,13 +26,12 @@
 
   <worldbody>
     <body name="base_link">
-      <inertial pos="0 0 0.035" mass="60" diaginertia="0.001 0.001 0.001"/>
       <joint name="joint_x" type="slide" axis="1 0 0"/>
       <joint name="joint_y" type="slide" axis="0 1 0"/>
       <joint name="joint_th"/>
       <geom class="visual" mesh="bumper" material="black"/>
       <geom class="visual" mesh="bottom_plate" material="dark_gray"/>
-      <geom class="visual" mesh="body" material="gray"/>
+      <geom class="visual" mesh="body" material="gray" mass="60"/>
       <geom class="visual" mesh="top_plate" material="dark_gray"/>
       <geom class="visual" mesh="arm_plate" material="gray"/>
       <geom class="collision" mesh="bumper"/>


### PR DESCRIPTION
`stanford_tidybot/base.xml` still has the placeholder inertial that #281 removed from `tidybot.xml`:

```xml
<inertial pos="0 0 0.035" mass="60" diaginertia="0.001 0.001 0.001"/>
```

Issue #231 named `base.xml` as the affected file. #281 ("Fixes #231", merged 2026-05-19) changed only `tidybot.xml` and closed the issue, so anyone loading `scene_base.xml`, which includes `base.xml`, still gets the original behavior.

## Measured

`mujoco` on `stanford_tidybot/scene_base.xml`, body `base_link`:

```
before  mass=60.0 kg  diaginertia=[0.001000 0.001000 0.001000] kg m^2
after   mass=60.0 kg  diaginertia=[1.902995 1.218462 1.213058] kg m^2
```

1 N.m of yaw torque gives 1000 rad/s^2 before and 0.82 rad/s^2 after, a factor of about 1200. That matches the report in #231 of the base spinning "at infinite speed with the slightest force when using position control and rotating the robot", and it means every contact interaction with the base was wrong by three orders of magnitude.

## The change

The same three edits #281 made to `tidybot.xml`, applied to `base.xml`:

- `<geom mass="0"/>` on the parent default, so the plates and bumper contribute no mass
- the placeholder `<inertial>` removed
- `mass="60"` on the body mesh geom, so MuJoCo derives the inertia from the mesh

Plus a `CHANGELOG.md` entry, since that file asks for notable changes to the model.

## Notes

The `<geom mass="0"/>` default sits at the root of `base.xml` because that is the structural equivalent of where #281 put it in `tidybot.xml`, under the parent of the `visual` and `collision` classes. `scene_base.xml` adds one `floor` plane geom that the default therefore also reaches; it is a static world geom, and the measured numbers above are from `scene_base.xml`, so that path is covered.

I did not add myself to `CONTRIBUTORS.md`. #281 did not, and it seemed better to keep this to one concern.
